### PR TITLE
Move S2 cell union code to src/geometry/s2_cell_union.rs

### DIFF
--- a/octree_web_viewer/src/backend.rs
+++ b/octree_web_viewer/src/backend.rs
@@ -46,7 +46,7 @@ pub fn get_visible_nodes(
                 }
             };
 
-            let visible_nodes = { octree.get_visible_nodes(&matrix) };
+            let visible_nodes = octree.get_visible_nodes(&matrix);
             let mut reply = String::from("[");
             let visible_nodes_string = visible_nodes
                 .iter()

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -2,7 +2,9 @@
 mod aabb;
 mod frustum;
 mod obb;
+mod s2_cell_union;
 
 pub use aabb::*;
 pub use frustum::*;
 pub use obb::*;
+pub use s2_cell_union::*;

--- a/src/geometry/s2_cell_union.rs
+++ b/src/geometry/s2_cell_union.rs
@@ -1,0 +1,33 @@
+//! A cell union, re-exported from the s2 crate.
+pub use s2::cellunion::CellUnion;
+
+use crate::geometry::Aabb;
+use crate::math::base::PointCulling;
+use crate::math::sat::ConvexPolyhedron;
+use crate::math::FromPoint3;
+use nalgebra::{Point3, RealField};
+use s2::{cell::Cell, cellid::CellID, region::Region};
+
+impl<S> PointCulling<S> for CellUnion
+where
+    S: RealField,
+    f64: From<S>,
+{
+    fn contains(&self, p: &Point3<S>) -> bool {
+        self.contains_cellid(&CellID::from_point(p))
+    }
+
+    fn intersects_aabb(&self, aabb: &Aabb<S>) -> bool {
+        let aabb_corner_cells = aabb
+            .compute_corners()
+            .iter()
+            .map(|p| CellID::from_point(p))
+            .collect();
+        let mut aabb_cell_union = CellUnion(aabb_corner_cells);
+        aabb_cell_union.normalize();
+        let rect = aabb_cell_union.rect_bound();
+        self.0
+            .iter()
+            .any(|cell_id| rect.intersects_cell(&Cell::from(cell_id)))
+    }
+}

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -15,10 +15,6 @@
 use crate::geometry::Aabb;
 use nalgebra::{Isometry3, Point3, RealField, Scalar, UnitQuaternion, Vector3};
 use nav_types::{ECEF, WGS84};
-use s2::cell::Cell;
-use s2::cellid::CellID;
-use s2::cellunion::CellUnion;
-use s2::region::Region;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
@@ -145,47 +141,6 @@ where
 
     fn intersects_aabb(&self, _aabb: &Aabb<S>) -> bool {
         true
-    }
-}
-
-pub fn cell_union_intersects_aabb<S>(
-    cell_union: &CellUnion,
-    aabb: &crate::geometry::Aabb<S>,
-) -> Relation
-where
-    S: RealField,
-    f64: From<S>,
-{
-    let aabb_corner_cells = aabb
-        .compute_corners()
-        .iter()
-        .map(|p| CellID::from_point(p))
-        .collect();
-    let mut aabb_cell_union = CellUnion(aabb_corner_cells);
-    aabb_cell_union.normalize();
-    let rect = aabb_cell_union.rect_bound();
-    let intersects = cell_union
-        .0
-        .iter()
-        .any(|cell_id| rect.intersects_cell(&Cell::from(cell_id)));
-    if intersects {
-        Relation::Cross
-    } else {
-        Relation::Out
-    }
-}
-
-impl<S> PointCulling<S> for CellUnion
-where
-    S: RealField,
-    f64: From<S>,
-{
-    fn contains(&self, p: &Point3<S>) -> bool {
-        self.contains_cellid(&CellID::from_point(p))
-    }
-
-    fn intersects_aabb(&self, aabb: &Aabb<S>) -> bool {
-        cell_union_intersects_aabb(self, aabb) != Relation::Out
     }
 }
 

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -15,8 +15,8 @@ use crate::data_provider::DataProvider;
 use crate::errors::*;
 use crate::geometry::{Aabb, Cube, Frustum};
 use crate::iterator::{PointCloud, PointLocation};
-use crate::math::sat::{ConvexPolyhedron, Intersector};
-use crate::math::{cell_union_intersects_aabb, Relation};
+use crate::math::base::PointCulling;
+use crate::math::sat::{ConvexPolyhedron, Intersector, Relation};
 use crate::proto;
 use crate::read_write::{Encoding, NodeIterator, PositionEncoding};
 use crate::{AttributeDataType, PointCloudMeta, CURRENT_VERSION};
@@ -328,7 +328,7 @@ impl PointCloud for Octree {
             PointLocation::Obb(obb) => node_ids_for_intersector(obb.intersector()),
             PointLocation::S2Cells(cu) => NodeIdsIterator::new(&self, |node_id, octree| {
                 let aabb = octree.nodes[&node_id].bounding_cube.to_aabb();
-                cell_union_intersects_aabb(cu, &aabb) != Relation::Out
+                cu.intersects_aabb(&aabb)
             })
             .collect(),
         }


### PR DESCRIPTION
This is to make src/math.rs less of a grab-bag. I think having this here makes sense because an S2 cell union is one of the query types, like Aabb, Obb and Frustum, and it is a geometric construct.