### PR TITLE
Replace ad-hoc "caching" structures for intersection testing with trait

### DIFF
--- a/src/geometry/aabb.rs
+++ b/src/geometry/aabb.rs
@@ -1,7 +1,7 @@
 //! Axis-aligned box and cube.
 
-use crate::math::sat::{self, ConvexPolyhedron, Intersector, Relation};
-use crate::math::PointCulling;
+use crate::math::base::{HasAabbIntersector, PointCulling};
+use crate::math::sat::{CachedAxesIntersector, ConvexPolyhedron, Intersector};
 use crate::proto;
 use arrayvec::ArrayVec;
 use nalgebra::{Isometry3, Point3, RealField, Vector3};
@@ -98,13 +98,18 @@ where
     fn contains(&self, p: &Point3<S>) -> bool {
         self.contains(p)
     }
+}
 
-    fn intersects_aabb(&self, aabb: &Aabb<S>) -> bool {
-        sat::sat(
-            ArrayVec::from([Vector3::x_axis(), Vector3::y_axis(), Vector3::z_axis()]),
-            &self.compute_corners(),
-            &aabb.compute_corners(),
-        ) != Relation::Out
+impl<'a, S> HasAabbIntersector<'a, S> for Aabb<S>
+where
+    S: RealField + num_traits::Bounded,
+{
+    type Intersector = CachedAxesIntersector<S>;
+    fn aabb_intersector(&'a self) -> CachedAxesIntersector<S> {
+        CachedAxesIntersector {
+            axes: vec![Vector3::x_axis(), Vector3::y_axis(), Vector3::z_axis()],
+            corners: self.compute_corners(),
+        }
     }
 }
 

--- a/src/geometry/aabb.rs
+++ b/src/geometry/aabb.rs
@@ -91,19 +91,13 @@ impl From<&Aabb<f64>> for proto::AxisAlignedCuboid {
     }
 }
 
-impl<S> PointCulling<S> for Aabb<S>
-where
-    S: RealField + num_traits::Bounded,
-{
+impl<S: RealField> PointCulling<S> for Aabb<S> {
     fn contains(&self, p: &Point3<S>) -> bool {
         self.contains(p)
     }
 }
 
-impl<'a, S> HasAabbIntersector<'a, S> for Aabb<S>
-where
-    S: RealField + num_traits::Bounded,
-{
+impl<'a, S: RealField> HasAabbIntersector<'a, S> for Aabb<S> {
     type Intersector = CachedAxesIntersector<S>;
     fn aabb_intersector(&'a self) -> CachedAxesIntersector<S> {
         CachedAxesIntersector {
@@ -113,10 +107,7 @@ where
     }
 }
 
-impl<S> ConvexPolyhedron<S> for Aabb<S>
-where
-    S: RealField,
-{
+impl<S: RealField> ConvexPolyhedron<S> for Aabb<S> {
     fn compute_corners(&self) -> [Point3<S>; 8] {
         [
             Point3::new(self.mins.x, self.mins.y, self.mins.z),

--- a/src/geometry/frustum.rs
+++ b/src/geometry/frustum.rs
@@ -127,12 +127,7 @@ impl<S: RealField> PointCulling<S> for Frustum<S> {
     }
 }
 
-impl<'a, S: RealField> HasAabbIntersector<'a, S> for Frustum<S> {
-    type Intersector = CachedAxesIntersector<S>;
-    fn aabb_intersector(&'a self) -> Self::Intersector {
-        self.intersector().cache_separating_axes_for_aabb()
-    }
-}
+has_aabb_intersector_for_convex_polyhedron!(Frustum<S>);
 
 impl<S: RealField> ConvexPolyhedron<S> for Frustum<S> {
     #[rustfmt::skip]

--- a/src/geometry/frustum.rs
+++ b/src/geometry/frustum.rs
@@ -1,11 +1,9 @@
 //! An asymmetric frustum with an arbitrary 3D pose.
 
-use crate::geometry::Aabb;
-use crate::math::sat::{CachedAxesIntersector, ConvexPolyhedron, Intersector, Relation};
-use crate::math::PointCulling;
+use crate::math::base::{HasAabbIntersector, PointCulling};
+use crate::math::sat::{CachedAxesIntersector, ConvexPolyhedron, Intersector};
 use arrayvec::ArrayVec;
 use nalgebra::{Isometry3, Matrix4, Perspective3, Point3, RealField, Unit};
-use num_traits::Bounded;
 use serde::{Deserialize, Serialize};
 
 /// A perspective projection matrix analogous to cgmath::Perspective.
@@ -101,22 +99,6 @@ pub struct Frustum<S: RealField> {
     clip_from_query: Matrix4<S>,
 }
 
-/// TODO(nnmm): Remove
-pub struct CachedAxesFrustum<S: RealField> {
-    frustum: Frustum<S>,
-    separating_axes: CachedAxesIntersector<S>,
-}
-
-impl<S: RealField + Bounded> CachedAxesFrustum<S> {
-    pub fn new(frustum: Frustum<S>) -> Self {
-        let separating_axes = frustum.intersector().cache_separating_axes_for_aabb();
-        Self {
-            frustum,
-            separating_axes,
-        }
-    }
-}
-
 impl<S: RealField> Frustum<S> {
     pub fn new(query_from_eye: Isometry3<S>, clip_from_eye: Perspective<S>) -> Self {
         let clip_from_query = clip_from_eye.as_matrix() * query_from_eye.inverse().to_homogeneous();
@@ -137,18 +119,21 @@ impl<S: RealField> Frustum<S> {
     }
 }
 
-impl<S> PointCulling<S> for CachedAxesFrustum<S>
+impl<S> PointCulling<S> for Frustum<S>
 where
     S: RealField,
 {
     fn contains(&self, point: &Point3<S>) -> bool {
-        let p_clip = self.frustum.clip_from_query.transform_point(point);
+        let p_clip = self.clip_from_query.transform_point(point);
         p_clip.coords.min() > nalgebra::convert(-1.0)
             && p_clip.coords.max() < nalgebra::convert(1.0)
     }
+}
 
-    fn intersects_aabb(&self, aabb: &Aabb<S>) -> bool {
-        self.separating_axes.intersect(&aabb.compute_corners()) != Relation::Out
+impl<'a, S: RealField> HasAabbIntersector<'a, S> for Frustum<S> {
+    type Intersector = CachedAxesIntersector<S>;
+    fn aabb_intersector(&'a self) -> Self::Intersector {
+        self.intersector().cache_separating_axes_for_aabb()
     }
 }
 

--- a/src/geometry/frustum.rs
+++ b/src/geometry/frustum.rs
@@ -119,10 +119,7 @@ impl<S: RealField> Frustum<S> {
     }
 }
 
-impl<S> PointCulling<S> for Frustum<S>
-where
-    S: RealField,
-{
+impl<S: RealField> PointCulling<S> for Frustum<S> {
     fn contains(&self, point: &Point3<S>) -> bool {
         let p_clip = self.clip_from_query.transform_point(point);
         p_clip.coords.min() > nalgebra::convert(-1.0)
@@ -137,10 +134,7 @@ impl<'a, S: RealField> HasAabbIntersector<'a, S> for Frustum<S> {
     }
 }
 
-impl<S> ConvexPolyhedron<S> for Frustum<S>
-where
-    S: RealField,
-{
+impl<S: RealField> ConvexPolyhedron<S> for Frustum<S> {
     #[rustfmt::skip]
     fn compute_corners(&self) -> [Point3<S>; 8] {
         let corner_from = |x, y, z| self.query_from_clip.transform_point(&Point3::new(x, y, z));

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -3,10 +3,8 @@ mod aabb;
 mod frustum;
 mod obb;
 mod s2_cell_union;
-mod web_mercator_tile;
 
 pub use aabb::*;
 pub use frustum::*;
 pub use obb::*;
 pub use s2_cell_union::*;
-pub use web_mercator_tile::*;

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -3,8 +3,10 @@ mod aabb;
 mod frustum;
 mod obb;
 mod s2_cell_union;
+mod web_mercator_tile;
 
 pub use aabb::*;
 pub use frustum::*;
 pub use obb::*;
 pub use s2_cell_union::*;
+pub use web_mercator_tile::*;

--- a/src/geometry/obb.rs
+++ b/src/geometry/obb.rs
@@ -15,13 +15,6 @@ pub struct Obb<S: RealField> {
     half_extent: Vector3<S>,
 }
 
-impl<'a, S: RealField> HasAabbIntersector<'a, S> for Obb<S> {
-    type Intersector = CachedAxesIntersector<S>;
-    fn aabb_intersector(&'a self) -> Self::Intersector {
-        self.intersector().cache_separating_axes_for_aabb()
-    }
-}
-
 impl<S: RealField> From<&Aabb<S>> for Obb<S> {
     fn from(aabb: &Aabb<S>) -> Self {
         Obb::new(
@@ -82,6 +75,8 @@ impl<S: RealField> ConvexPolyhedron<S> for Obb<S> {
         }
     }
 }
+
+has_aabb_intersector_for_convex_polyhedron!(Obb<S>);
 
 impl<S: RealField> PointCulling<S> for Obb<S> {
     fn contains(&self, p: &Point3<S>) -> bool {

--- a/src/geometry/obb.rs
+++ b/src/geometry/obb.rs
@@ -5,7 +5,6 @@ use crate::math::sat::{CachedAxesIntersector, ConvexPolyhedron, Intersector};
 use crate::math::{HasAabbIntersector, PointCulling};
 use arrayvec::ArrayVec;
 use nalgebra::{Isometry3, Point3, RealField, Unit, UnitQuaternion, Vector3};
-use num_traits::Bounded;
 use serde::{Deserialize, Serialize};
 
 /// An oriented bounding box.
@@ -14,22 +13,6 @@ pub struct Obb<S: RealField> {
     query_from_obb: Isometry3<S>,
     obb_from_query: Isometry3<S>,
     half_extent: Vector3<S>,
-}
-
-/// TODO(nnmm): Remove
-pub struct CachedAxesObb<S: RealField> {
-    pub obb: Obb<S>,
-    pub separating_axes: CachedAxesIntersector<S>,
-}
-
-impl<S: RealField + Bounded> CachedAxesObb<S> {
-    pub fn new(obb: Obb<S>) -> Self {
-        let separating_axes = obb.intersector().cache_separating_axes_for_aabb();
-        Self {
-            obb,
-            separating_axes,
-        }
-    }
 }
 
 impl<'a, S: RealField> HasAabbIntersector<'a, S> for Obb<S> {
@@ -68,10 +51,7 @@ impl<S: RealField> Obb<S> {
     }
 }
 
-impl<S> ConvexPolyhedron<S> for Obb<S>
-where
-    S: RealField,
-{
+impl<S: RealField> ConvexPolyhedron<S> for Obb<S> {
     fn compute_corners(&self) -> [Point3<S>; 8] {
         let corner_from = |x, y, z| self.query_from_obb * Point3::new(x, y, z);
         [
@@ -103,10 +83,7 @@ where
     }
 }
 
-impl<S> PointCulling<S> for Obb<S>
-where
-    S: RealField,
-{
+impl<S: RealField> PointCulling<S> for Obb<S> {
     fn contains(&self, p: &Point3<S>) -> bool {
         let p = self.obb_from_query * p;
         p.x.abs() <= self.half_extent.x

--- a/src/geometry/s2_cell_union.rs
+++ b/src/geometry/s2_cell_union.rs
@@ -8,7 +8,7 @@ use crate::math::FromPoint3;
 use nalgebra::{Point3, RealField};
 use s2::{cell::Cell, cellid::CellID, region::Region};
 
-/// Checks for an intersection between a cell_union and a polyhedron.
+/// Checks for an intersection between a list of cells and a polyhedron.
 ///
 /// This is done by checking whether an cell in the cell union intersects
 /// a covering of the polyhedron with S2 cells.

--- a/src/geometry/s2_cell_union.rs
+++ b/src/geometry/s2_cell_union.rs
@@ -51,9 +51,10 @@ where
     }
 }
 
-impl<'a, S: RealField> HasAabbIntersector<'a, S> for CellUnion
+impl<'a, S> HasAabbIntersector<'a, S> for CellUnion
 where
     f64: From<S>,
+    S: RealField,
 {
     type Intersector = Vec<Cell>;
     fn aabb_intersector(&'a self) -> Self::Intersector {

--- a/src/geometry/s2_cell_union.rs
+++ b/src/geometry/s2_cell_union.rs
@@ -10,7 +10,7 @@ use s2::{cell::Cell, cellid::CellID, region::Region};
 
 /// Checks for an intersection between a list of cells and a polyhedron.
 ///
-/// This is done by checking whether an cell in the cell union intersects
+/// This is done by checking whether any cell in the list intersects
 /// a covering of the polyhedron with S2 cells.
 pub fn cells_intersecting_polyhedron<S>(
     cells: &[Cell],

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -38,11 +38,12 @@ impl PointLocation {
 }
 
 /// This macro is an alternative to `get_point_culling()`, to be used where
-/// performance is important (i.e. in an inner loop). This can make a difference    
-/// of 5-10 % in queries measuered by the point_cloud_test crate.   
-/// It receives a function that accepts a _specific_ PointCulling object.
-/// Besides the object not being boxed, this way we can be sure that    
-/// there is no overhead from matching against the PointLocation inside the
+/// performance is important (i.e. in an inner loop). This can make a difference
+/// of 5-10 % in queries measuered by the `point_cloud_test` crate.
+/// It receives a function that accepts a _specific_ geometry object, which
+/// implements `PointCulling` and `HasAabbIntersector`.
+/// Besides the object not being boxed, this way we can be sure that
+/// there is no overhead from matching against the `PointLocation` inside the
 /// function as well, as you might get with the `enum_dispatch` crate.
 ///
 /// Syntax: dispatch_point_location!(func, point_location, args*), which

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod data_provider;
 #[allow(deprecated)]
 pub mod errors;
 pub mod geometry;
+#[macro_use]
 pub mod iterator;
 pub mod math;
 pub mod octree;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Needs to be first, because we're using macros from here in the geometry module
+// and Rust's handling of macros is insane and depends on module order
+#[macro_use]
+pub mod math;
+
 #[macro_use]
 pub mod attributes;
 pub mod color;
@@ -21,7 +27,6 @@ pub mod errors;
 pub mod geometry;
 #[macro_use]
 pub mod iterator;
-pub mod math;
 pub mod octree;
 pub mod read_write;
 pub mod s2_cells;

--- a/src/math/base.rs
+++ b/src/math/base.rs
@@ -1,10 +1,37 @@
 use crate::geometry::Aabb;
+use crate::math::sat::{CachedAxesIntersector, ConvexPolyhedron, Relation};
 use nalgebra::{Point3, RealField};
+use num_traits::Bounded;
 
 pub trait PointCulling<S>
 where
     S: RealField,
 {
     fn contains(&self, point: &Point3<S>) -> bool;
-    fn intersects_aabb(&self, aabb: &Aabb<S>) -> bool;
+}
+
+/// Something that can perform an intersection test with an AABB.
+pub trait IntersectAabb<S: RealField> {
+    // TODO(nnmm): return Relation
+    fn intersect_aabb(&self, aabb: &Aabb<S>) -> bool;
+}
+
+/// We use this trait to allow an indirection: The geometry itself does not need to be able to
+/// efficiently do intersection tests with AABBs, because the geometry (e.g. an OBB) should not need
+/// to store data to support intersection tests (like separating axes).
+/// The trait has a lifetime to support the intersector borrowing from self, or being identical to
+/// &Self.
+///
+/// Having `impl<'a, T: IntersectAabb<S>, S> HasAabbIntersector<'a, S> for T` and
+/// `impl<'a, S, T: ConvexPolyhedron<S>> HasAabbIntersector<'a, S> for T` would be nice, but results
+/// in conflicts.
+pub trait HasAabbIntersector<'a, S: RealField> {
+    type Intersector: IntersectAabb<S> + 'a;
+    fn aabb_intersector(&'a self) -> Self::Intersector;
+}
+
+impl<S: RealField + Bounded> IntersectAabb<S> for CachedAxesIntersector<S> {
+    fn intersect_aabb(&self, aabb: &Aabb<S>) -> bool {
+        self.intersect(&aabb.compute_corners()) != Relation::Out
+    }
 }

--- a/src/math/base.rs
+++ b/src/math/base.rs
@@ -35,3 +35,16 @@ impl<S: RealField + Bounded> IntersectAabb<S> for CachedAxesIntersector<S> {
         self.intersect(&aabb.compute_corners()) != Relation::Out
     }
 }
+
+/// Use this macro as a crutch for the missing
+/// `impl<'a, S, T: ConvexPolyhedron<S>> HasAabbIntersector<'a, S> for T`.
+macro_rules! has_aabb_intersector_for_convex_polyhedron {
+	($type:ty) => (
+		impl<'a, S: RealField> HasAabbIntersector<'a, S> for $type {
+			type Intersector = CachedAxesIntersector<S>;
+		    fn aabb_intersector(&'a self) -> Self::Intersector {
+		    	self.intersector().cache_separating_axes_for_aabb()
+		    }
+		}
+	)
+}

--- a/src/math/base.rs
+++ b/src/math/base.rs
@@ -39,12 +39,12 @@ impl<S: RealField + Bounded> IntersectAabb<S> for CachedAxesIntersector<S> {
 /// Use this macro as a crutch for the missing
 /// `impl<'a, S, T: ConvexPolyhedron<S>> HasAabbIntersector<'a, S> for T`.
 macro_rules! has_aabb_intersector_for_convex_polyhedron {
-	($type:ty) => (
-		impl<'a, S: RealField> HasAabbIntersector<'a, S> for $type {
-			type Intersector = CachedAxesIntersector<S>;
-		    fn aabb_intersector(&'a self) -> Self::Intersector {
-		    	self.intersector().cache_separating_axes_for_aabb()
-		    }
-		}
-	)
+    ($type:ty) => {
+        impl<'a, S: RealField> HasAabbIntersector<'a, S> for $type {
+            type Intersector = CachedAxesIntersector<S>;
+            fn aabb_intersector(&'a self) -> Self::Intersector {
+                self.intersector().cache_separating_axes_for_aabb()
+            }
+        }
+    };
 }

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -127,19 +127,29 @@ where
     }
 }
 
-/// Implementation of PointCulling to return all points
-#[derive(Clone, Debug, Serialize, Deserialize)]
+/// Implementation of PointCulling which returns all points
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct AllPoints {}
+
+impl<S: RealField> IntersectAabb<S> for AllPoints {
+    fn intersect_aabb(&self, _aabb: &Aabb<S>) -> bool {
+        true
+    }
+}
+
+impl<'a, S: RealField> HasAabbIntersector<'a, S> for AllPoints {
+    type Intersector = Self;
+
+    fn aabb_intersector(&'a self) -> Self::Intersector {
+        *self
+    }
+}
 
 impl<S> PointCulling<S> for AllPoints
 where
-    S: RealField + num_traits::Bounded,
+    S: RealField,
 {
     fn contains(&self, _p: &Point3<S>) -> bool {
-        true
-    }
-
-    fn intersects_aabb(&self, _aabb: &Aabb<S>) -> bool {
         true
     }
 }
@@ -168,7 +178,7 @@ pub fn local_frame_from_lat_lng(lat: f64, lon: f64) -> Isometry3<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::geometry::{Aabb, CachedAxesFrustum, Frustum, Perspective};
+    use crate::geometry::{Aabb, Frustum, Perspective};
     use nalgebra::{UnitQuaternion, Vector3};
 
     #[test]
@@ -198,8 +208,7 @@ mod tests {
             frustum.intersector().intersect(&bbox.intersector()),
             Relation::In
         );
-        let frustum_aabb_intersector = CachedAxesFrustum::new(frustum);
-        assert!(frustum_aabb_intersector.contains(&bbox_min));
-        assert!(frustum_aabb_intersector.contains(&bbox_max));
+        assert!(frustum.contains(&bbox_min));
+        assert!(frustum.contains(&bbox_max));
     }
 }

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 
+#[macro_use]
 pub mod base;
 pub mod sat;
 pub use base::*;

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -330,13 +330,7 @@ impl PointCloud for Octree {
     type Id = NodeId;
 
     fn nodes_in_location(&self, location: &PointLocation) -> Vec<Self::Id> {
-        match location {
-            PointLocation::AllPoints => self.nodes_in_location_impl(&AllPoints {}),
-            PointLocation::Aabb(aabb) => self.nodes_in_location_impl(aabb),
-            PointLocation::Frustum(f) => self.nodes_in_location_impl(f),
-            PointLocation::Obb(obb) => self.nodes_in_location_impl(obb),
-            PointLocation::S2Cells(cu) => self.nodes_in_location_impl(cu),
-        }
+        dispatch_point_location!(Octree::nodes_in_location_impl, location, &self)
     }
 
     fn encoding_for_node(&self, id: Self::Id) -> Encoding {


### PR DESCRIPTION
As a motivation, let me summarize a few things about how octrees are queried:
* A query for data in a geometric primitive, like an Obb, is made
* The usual representation of that geometric primitive doesn't support efficient intersection testing, instead it needs to compute derived data (intersecting axes usually, but `Cell` for the `CellID`s in S2 queries)
* We do many intersection tests against different octree nodes, and the computed data should not get re-computed each time, instead it should get cached/reused.
* Then, once nodes are identified, the points in them are filtered using the `PointCulling` trait's `contains()` method.

Currently the caching is done in a pretty ad-hoc manner:
* Frustum and Obb currently define an extra struct that holds the separating axes.
* There is no caching for S2 and Aabb queries.
* AllPoints queries do not need caching.

With this change:
* The part about intersection testing is spilt off from point filtering, i.e. `PointCulling` no longer has an `intersect_aabb()` method.
* Instead, all the `PointLocation` variants implement a trait to _produce_ an intersection testing structure (it can be identical to itself) named `HasAabbIntersector`.
* The produced intersection testing structure or "intersector" can borrow from, or be identical to, the geometric primitive. It can be reused many times and implements the actual `IntersectAabb` trait.

Benefits:
* Better performance by caching S2 and Aabb queries
* We can now write generic code over all `PointLocation` variants which receives an `impl HasAabbIntersector`. Compare `nodes_in_location()` in octree/mod.rs.
* Capturing de-facto patterns like this with traits seems like a good idea because it forces new queries to follow them and it's cognitively easier: If you have something that implements `HasAabbIntersector`, you know you can search the octree nodes with it.

Drawbacks:
* We should be able to tell Rust that any `ConvexPolyhedron` implementor is also a `HasAabbIntersector` implementor, but I got some conflicting traits errors. Resolving this would save us a few boilerplate implementations.
