### PR TITLE
Add a test for PointCulling/ConvexPolyhedron consistency

### DIFF
--- a/point_cloud_test/src/lib.rs
+++ b/point_cloud_test/src/lib.rs
@@ -12,11 +12,10 @@ use std::path::{Path, PathBuf};
 use std::sync::Once;
 use tempdir::TempDir;
 
-mod synthetic_data;
+pub mod synthetic_data;
 pub use synthetic_data::{Batched, SyntheticData};
 
-mod queries;
-pub use queries::{get_abb_query, get_cell_union_query, get_frustum_query, get_obb_query};
+pub mod queries;
 
 pub const S2_LEVEL: u64 = 20;
 

--- a/point_cloud_test/src/queries.rs
+++ b/point_cloud_test/src/queries.rs
@@ -20,16 +20,16 @@ pub fn get_aabb_query(data: SyntheticData) -> PointLocation {
 // An OBB that lies in the center of the point cloud and is aligned with gravity.
 // Its half-extent is half of that of the data.
 pub fn get_obb(data: SyntheticData) -> Obb<f64> {
-    let obb = Obb::new(
+    Obb::new(
         *data.ecef_from_local(),
         Vector3::new(
             0.5 * data.half_width,
             0.5 * data.half_width,
             0.5 * data.half_height,
         ),
-    );
-    obb
+    )
 }
+
 pub fn get_obb_query(data: SyntheticData) -> PointLocation {
     PointLocation::Obb(get_obb(data))
 }

--- a/point_cloud_test/src/queries.rs
+++ b/point_cloud_test/src/queries.rs
@@ -2,19 +2,24 @@
 use crate::synthetic_data::SyntheticData;
 use crate::S2_LEVEL;
 use nalgebra::{Perspective3, Point3, Vector3};
-use point_viewer::geometry::{Frustum, Obb};
+use point_viewer::geometry::{Aabb, CellUnion, Frustum, Obb};
 use point_viewer::iterator::PointLocation;
 use point_viewer::math::FromPoint3;
 use s2::cellid::CellID;
 
-pub fn get_abb_query(data: SyntheticData) -> PointLocation {
-    let abb = data.bbox();
-    PointLocation::Aabb(abb)
+pub fn get_aabb(data: SyntheticData) -> Aabb<f64> {
+    let min_corner = data.bbox().min() + 0.2 * data.bbox().diag();
+    let max_corner = data.bbox().min() + 0.8 * data.bbox().diag();
+    Aabb::new(min_corner, max_corner)
+}
+
+pub fn get_aabb_query(data: SyntheticData) -> PointLocation {
+    PointLocation::Aabb(get_aabb(data))
 }
 
 // An OBB that lies in the center of the point cloud and is aligned with gravity.
 // Its half-extent is half of that of the data.
-pub fn get_obb_query(data: SyntheticData) -> PointLocation {
+pub fn get_obb(data: SyntheticData) -> Obb<f64> {
     let obb = Obb::new(
         *data.ecef_from_local(),
         Vector3::new(
@@ -23,20 +28,29 @@ pub fn get_obb_query(data: SyntheticData) -> PointLocation {
             0.5 * data.half_height,
         ),
     );
-    PointLocation::Obb(obb)
+    obb
 }
-pub fn get_frustum_query(data: SyntheticData) -> PointLocation {
+pub fn get_obb_query(data: SyntheticData) -> PointLocation {
+    PointLocation::Obb(get_obb(data))
+}
+
+pub fn get_frustum(data: SyntheticData) -> Frustum<f64> {
     let ecef_from_local = *data.ecef_from_local();
     let perspective = Perspective3::new(
         /* aspect */ 1.0, /* fovy */ 1.2, /* near */ 0.1, /* far */ 10.0,
     );
-    let frustum = Frustum::new(ecef_from_local, perspective.into());
-    PointLocation::Frustum(frustum)
+    Frustum::new(ecef_from_local, perspective.into())
+}
+pub fn get_frustum_query(data: SyntheticData) -> PointLocation {
+    PointLocation::Frustum(get_frustum(data))
+}
+
+pub fn get_cell_union(data: SyntheticData) -> CellUnion {
+    let coords = data.ecef_from_local().translation.vector;
+    let s2_cell_id = CellID::from_point(&Point3 { coords }).parent(S2_LEVEL);
+    CellUnion(vec![s2_cell_id, s2_cell_id.next()])
 }
 
 pub fn get_cell_union_query(data: SyntheticData) -> PointLocation {
-    let coords = data.ecef_from_local().translation.vector;
-    let s2_cell_id = CellID::from_point(&Point3 { coords }).parent(S2_LEVEL);
-    let s2_cell_union = s2::cellunion::CellUnion(vec![s2_cell_id, s2_cell_id.next()]);
-    PointLocation::S2Cells(s2_cell_union)
+    PointLocation::S2Cells(get_cell_union(data))
 }

--- a/point_cloud_test/tests/main.rs
+++ b/point_cloud_test/tests/main.rs
@@ -80,7 +80,7 @@ where
     let (s2, oct, data) = setup_pointcloud(&args);
     let query = PointQuery {
         attributes: vec!["color"],
-        location: gen_location(data.clone()),
+        location: gen_location(data),
         ..Default::default()
     };
     let points_oct = query_and_sort(&oct, &query, args.batch_size);

--- a/point_cloud_test/tests/main.rs
+++ b/point_cloud_test/tests/main.rs
@@ -100,15 +100,17 @@ where
     let data = SyntheticData::new(args.width, args.height, args.num_points, args.seed);
     let c = gen_culling(data.clone());
     let intersector = c.intersector();
-    data.for_each(|p| {
+    let data_filtered = data.filter(|p| {
         let point = Point3::new(p.position.x, p.position.y, p.position.z);
         let sat_result = sat::sat(
             intersector.face_normals.iter().copied(),
             &intersector.corners,
             &[point],
-        );
-        assert!(c.contains(&point) == (sat_result == sat::Relation::In));
+        ) == sat::Relation::In;
+        assert!(c.contains(&point) == sat_result);
+        sat_result
     });
+    assert!(data_filtered.count() > 0);
 }
 
 fn query_and_sort<C>(point_cloud: &C, query: &PointQuery, batch_size: usize) -> Vec<IndexedPoint>

--- a/point_cloud_test/tests/main.rs
+++ b/point_cloud_test/tests/main.rs
@@ -1,11 +1,10 @@
 use nalgebra::{Point3, Vector3};
 use num_integer::div_ceil;
-use point_cloud_test_lib::{
-    get_abb_query, get_cell_union_query, get_frustum_query, get_obb_query, setup_pointcloud,
-    Arguments, SyntheticData,
-};
+use point_cloud_test_lib::queries::*;
+use point_cloud_test_lib::{setup_pointcloud, Arguments, SyntheticData};
 use point_viewer::iterator::PointCloud;
 use point_viewer::iterator::{PointLocation, PointQuery};
+use point_viewer::math::{sat, ConvexPolyhedron, PointCulling};
 use std::cmp::Ordering;
 
 #[test]
@@ -40,7 +39,7 @@ fn check_all_query_equality() {
 
 #[test]
 fn check_box_query_equality() {
-    check_equality(get_abb_query)
+    check_equality(get_aabb_query)
 }
 
 #[test]
@@ -58,6 +57,21 @@ fn check_cell_union_query_equality() {
     check_equality(get_cell_union_query)
 }
 
+#[test]
+fn check_box_point_culling_equality() {
+    check_point_culling_equality(get_aabb)
+}
+
+#[test]
+fn check_frustum_point_culling_equality() {
+    check_point_culling_equality(get_frustum)
+}
+
+#[test]
+fn check_obb_point_culling_equality() {
+    check_point_culling_equality(get_obb);
+}
+
 fn check_equality<F>(gen_location: F)
 where
     F: FnOnce(SyntheticData) -> PointLocation,
@@ -66,12 +80,35 @@ where
     let (s2, oct, data) = setup_pointcloud(&args);
     let query = PointQuery {
         attributes: vec!["color"],
-        location: gen_location(data),
+        location: gen_location(data.clone()),
         ..Default::default()
     };
     let points_oct = query_and_sort(&oct, &query, args.batch_size);
     let points_s2 = query_and_sort(&s2, &query, args.batch_size);
     assert_points_equal(&points_s2, &points_oct, args.resolution);
+}
+
+/// We have two implementations of a containment predicate on points:
+/// One via the `PointCulling` trait, and one via the `ConvexPolyhedron` trait.
+/// They should behave the same.
+fn check_point_culling_equality<F, C>(gen_culling: F)
+where
+    F: FnOnce(SyntheticData) -> C,
+    C: PointCulling<f64> + ConvexPolyhedron<f64>,
+{
+    let args = Arguments::default();
+    let data = SyntheticData::new(args.width, args.height, args.num_points, args.seed);
+    let c = gen_culling(data.clone());
+    let intersector = c.intersector();
+    data.for_each(|p| {
+        let point = Point3::new(p.position.x, p.position.y, p.position.z);
+        let sat_result = sat::sat(
+            intersector.face_normals.iter().copied(),
+            &intersector.corners,
+            &[point],
+        );
+        assert!(c.contains(&point) == (sat_result == sat::Relation::In));
+    });
 }
 
 fn query_and_sort<C>(point_cloud: &C, query: &PointQuery, batch_size: usize) -> Vec<IndexedPoint>

--- a/point_cloud_test/tests/main.rs
+++ b/point_cloud_test/tests/main.rs
@@ -110,7 +110,10 @@ where
         assert!(c.contains(&point) == sat_result);
         sat_result
     });
-    assert!(data_filtered.count() > 0);
+    assert!(
+        data_filtered.count() > 0,
+        "The query returned no points (using PointCulling only)"
+    );
 }
 
 fn query_and_sort<C>(point_cloud: &C, query: &PointQuery, batch_size: usize) -> Vec<IndexedPoint>
@@ -133,7 +136,10 @@ where
             .unwrap();
     }
     points.sort_unstable_by(|p1, p2| p1.idx.cmp(&p2.idx));
-    assert!(!points.is_empty());
+    assert!(
+        !points.is_empty(),
+        "The query returned no points (using streaming)"
+    );
     points
 }
 


### PR DESCRIPTION
We have two implementations of a containment predicate on points: One via the `PointCulling` trait, and one via the `ConvexPolyhedron` trait. They should behave the same.

This also fixes a bug in the tests where the Aabb was equal to the entire point cloud's bbox.