### PR TITLE
Properly handle errors in `merge_xray_quadtrees`.

### DIFF
--- a/xray/src/bin/merge_xray_quadtrees.rs
+++ b/xray/src/bin/merge_xray_quadtrees.rs
@@ -93,12 +93,13 @@ struct MergedMetadata {
 
 // Checks wheter all the elements in the iterator have the same value and returns it.
 // There must be at least one element in the iterator.
-fn all_equal<I, V>(iterator: I) -> Option<V>
+fn all_equal<I, V>(iterator: I, error_message: &str) -> io::Result<V>
 where
     I: Iterator<Item = V>,
     V: std::cmp::PartialEq,
 {
     all_equal_by_func(iterator, |left, right| left == right)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, error_message))
 }
 
 fn all_equal_by_func<I, V, F>(mut iterator: I, comp: F) -> Option<V>
@@ -115,22 +116,39 @@ where
     })
 }
 
-fn validate_and_merge_metadata(metadata: &[Meta]) -> MergedMetadata {
-    assert!(!metadata.is_empty(), "No subquadtrees meta files found.");
+fn validate_and_merge_metadata(metadata: &[Meta]) -> io::Result<MergedMetadata> {
+    if metadata.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "No subquadtrees meta files found.",
+        ));
+    }
     let root_nodes_vec = get_root_nodes(metadata);
-    assert!(!root_nodes_vec.is_empty(), "All subquadtress are empty.");
+    if root_nodes_vec.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "All subquadtress are empty.",
+        ));
+    }
     let root_node_ids: FnvHashSet<NodeId> = root_nodes_vec.iter().map(|node| node.id).collect();
-    assert_eq!(
-        root_node_ids.len(),
-        root_nodes_vec.len(),
-        "Not all roots are unique."
-    );
-    let level = all_equal(root_node_ids.iter().map(|node_id| node_id.level()))
-        .expect("Not all roots have the same level.");
-    let deepest_level = all_equal(metadata.iter().map(|meta| meta.deepest_level))
-        .expect("Not all meta files have the same deepest level.") as u8;
-    let tile_size = all_equal(metadata.iter().map(|meta| meta.tile_size))
-        .expect("Not all meta files have the same tile size.");
+    if root_node_ids.len() != root_nodes_vec.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Not all roots are unique.",
+        ));
+    }
+    let level = all_equal(
+        root_node_ids.iter().map(|node_id| node_id.level()),
+        "Not all roots have the same level.",
+    )?;
+    let deepest_level = all_equal(
+        metadata.iter().map(|meta| meta.deepest_level),
+        "Not all meta files have the same deepest level.",
+    )? as u8;
+    let tile_size = all_equal(
+        metadata.iter().map(|meta| meta.tile_size),
+        "Not all meta files have the same tile size.",
+    )?;
     let bounding_rect = {
         // This unwrap is safe by one of the assertions above.
         let mut root_node = root_nodes_vec.first().cloned().unwrap();
@@ -145,7 +163,7 @@ fn validate_and_merge_metadata(metadata: &[Meta]) -> MergedMetadata {
         nodes.extend(&meta.nodes);
     }
 
-    MergedMetadata {
+    Ok(MergedMetadata {
         root_node_ids,
         level,
         root_meta: Meta {
@@ -154,7 +172,7 @@ fn validate_and_merge_metadata(metadata: &[Meta]) -> MergedMetadata {
             bounding_rect,
             nodes,
         },
-    }
+    })
 }
 
 fn merge(mut metadata: MergedMetadata, output_directory: &Path, tile_background_color: Color<u8>) {
@@ -193,7 +211,7 @@ fn main() -> io::Result<()> {
         create_dir_all(&args.output_directory)?;
     }
     let metadata = read_metadata_from_directories(&args.input_directories)?;
-    let merged_metadata = validate_and_merge_metadata(&metadata);
+    let merged_metadata = validate_and_merge_metadata(&metadata)?;
     copy_all_images(&args.input_directories, &args.output_directory);
     merge(
         merged_metadata,

--- a/xray/src/bin/merge_xray_quadtrees.rs
+++ b/xray/src/bin/merge_xray_quadtrees.rs
@@ -112,18 +112,18 @@ where
 
 fn validate_input_directory(input_directory: &Path) -> io::Result<()> {
     if !input_directory.exists() {
-        return Err(io::Error::new(
+        Err(io::Error::new(
             io::ErrorKind::NotFound,
             format!("Input directory {:?} doesn't exist.", input_directory),
-        ));
-    }
-    if !input_directory.metadata()?.is_dir() {
-        return Err(io::Error::new(
+        ))
+    } else if !input_directory.metadata()?.is_dir() {
+        Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             format!("{:?} is not a directory.", input_directory),
-        ));
+        ))
+    } else {
+        Ok(())
     }
-    Ok(())
 }
 
 fn validate_and_merge_metadata(metadata: &[Meta]) -> io::Result<MergedMetadata> {

--- a/xray/src/bin/merge_xray_quadtrees.rs
+++ b/xray/src/bin/merge_xray_quadtrees.rs
@@ -5,7 +5,7 @@ use std::fs::create_dir_all;
 use std::io;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
-use xray::{generation, Meta, META_FILENAME};
+use xray::{generation, Meta, META_EXTENSION, META_FILENAME, META_PREFIX};
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "merge_xray_quadtrees")]
@@ -52,7 +52,7 @@ fn copy_all_images(input_directories: &[PathBuf], output_directory: &Path) -> io
 }
 
 fn read_metadata_from_directory(directory: &Path) -> io::Result<Vec<Meta>> {
-    globwalk::GlobWalkerBuilder::new(directory, "meta*.pb")
+    globwalk::GlobWalkerBuilder::new(directory, format!("{}*.{}", *META_PREFIX, *META_EXTENSION))
         .build()
         .expect("Failed to build GlobWalker")
         .filter_map(Result::ok)

--- a/xray/src/lib.rs
+++ b/xray/src/lib.rs
@@ -16,6 +16,19 @@ pub const CURRENT_VERSION: i32 = 3;
 pub const META_FILENAME: &str = "meta.pb";
 pub const IMAGE_FILE_EXTENSION: &str = "png";
 
+lazy_static::lazy_static! {
+    pub static ref META_PREFIX: &'static str = Path::new(META_FILENAME)
+        .file_stem()
+        .unwrap()
+        .to_str()
+        .unwrap();
+    pub static ref META_EXTENSION: &'static str = Path::new(META_FILENAME)
+        .extension()
+        .unwrap()
+        .to_str()
+        .unwrap();
+}
+
 #[derive(Debug, Clone)]
 pub struct Meta {
     pub nodes: FnvHashSet<NodeId>,

--- a/xray/src/utils.rs
+++ b/xray/src/utils.rs
@@ -1,21 +1,8 @@
-use crate::META_FILENAME;
+use crate::{META_EXTENSION, META_PREFIX};
 use image::{GenericImage, GenericImageView, ImageResult, Pixel, RgbaImage, SubImage};
 use quadtree::{NodeId, NODE_PREFIX};
 use std::io;
 use std::path::{Path, PathBuf};
-
-lazy_static::lazy_static! {
-    static ref META_PREFIX: &'static str = Path::new(META_FILENAME)
-        .file_stem()
-        .unwrap()
-        .to_str()
-        .unwrap();
-    static ref META_EXTENSION: &'static str = Path::new(META_FILENAME)
-        .extension()
-        .unwrap()
-        .to_str()
-        .unwrap();
-}
 
 pub fn get_meta_pb_path(directory: &Path, id: NodeId) -> PathBuf {
     directory
@@ -90,6 +77,7 @@ pub fn interpolate_subimages<W>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::META_FILENAME;
 
     #[test]
     fn node_id_to_paths_back_and_forth() {


### PR DESCRIPTION
Instead of using `unwraps/expects` use proper errors.