### PR TITLE
Build all targets in CI

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -13,7 +13,7 @@ main() {
 
     # root
     cargo clippy --workspace -- -D warnings
-    cargo build --workspace --verbose
+    cargo build --workspace --verbose --all-targets
     cargo test --workspace
 }
 


### PR DESCRIPTION
Previously, no benchmarks would get built (I think examples also might have been skipped). To quote the docs, "Build all targets. This is equivalent to specifying --lib --bins --tests --benches --examples."