### PR TITLE
Monomorphize all geometry primitives to use f64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,7 +2129,6 @@ dependencies = [
  "serde_derive",
  "structopt",
  "tempdir",
- "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ s2 = { version = "0.0.10", features = ["serde"] }
 serde = "1.0.104"
 serde_derive = "1.0.104"
 structopt = "0.3.11"
-walkdir = "2.3.1"
 rand = "0.7.3"
 
 [dependencies.point_viewer_proto_rust]

--- a/point_cloud_client/src/lib.rs
+++ b/point_cloud_client/src/lib.rs
@@ -13,14 +13,14 @@ enum PointClouds {
 
 pub struct PointCloudClient {
     point_clouds: PointClouds,
-    aabb: Aabb<f64>,
+    aabb: Aabb,
     num_points_per_batch: usize,
     num_threads: usize,
     buffer_size: usize,
 }
 
 impl PointCloudClient {
-    pub fn bounding_box(&self) -> &Aabb<f64> {
+    pub fn bounding_box(&self) -> &Aabb {
         &self.aabb
     }
 
@@ -98,8 +98,8 @@ impl<'a> PointCloudClientBuilder<'a> {
             .iter()
             .map(|location| self.data_provider_factory.generate_data_provider(location))
             .collect::<Result<Vec<Box<dyn DataProvider>>>>()?;
-        let mut aabb: Option<Aabb<f64>> = None;
-        let unite = |bbox: &Aabb<f64>, with: &mut Option<Aabb<f64>>| {
+        let mut aabb: Option<Aabb> = None;
+        let unite = |bbox: &Aabb, with: &mut Option<Aabb>| {
             let b = with.get_or_insert(bbox.clone());
             b.grow(*bbox.min());
             b.grow(*bbox.max());

--- a/point_cloud_test/src/queries.rs
+++ b/point_cloud_test/src/queries.rs
@@ -8,7 +8,7 @@ use point_viewer::iterator::PointLocation;
 use point_viewer::math::{FromPoint3, WebMercatorCoord};
 use s2::cellid::CellID;
 
-pub fn get_aabb(data: SyntheticData) -> Aabb<f64> {
+pub fn get_aabb(data: SyntheticData) -> Aabb {
     let min_corner = data.bbox().min() + 0.2 * data.bbox().diag();
     let max_corner = data.bbox().min() + 0.8 * data.bbox().diag();
     Aabb::new(min_corner, max_corner)
@@ -20,7 +20,7 @@ pub fn get_aabb_query(data: SyntheticData) -> PointLocation {
 
 // An OBB that lies in the center of the point cloud and is aligned with gravity.
 // Its half-extent is half of that of the data.
-pub fn get_obb(data: SyntheticData) -> Obb<f64> {
+pub fn get_obb(data: SyntheticData) -> Obb {
     Obb::new(
         *data.ecef_from_local(),
         Vector3::new(
@@ -35,7 +35,7 @@ pub fn get_obb_query(data: SyntheticData) -> PointLocation {
     PointLocation::Obb(get_obb(data))
 }
 
-pub fn get_frustum(data: SyntheticData) -> Frustum<f64> {
+pub fn get_frustum(data: SyntheticData) -> Frustum {
     let ecef_from_local = *data.ecef_from_local();
     let perspective = Perspective3::new(
         /* aspect */ 1.0, /* fovy */ 1.2, /* near */ 0.1, /* far */ 10.0,

--- a/point_cloud_test/src/synthetic_data.rs
+++ b/point_cloud_test/src/synthetic_data.rs
@@ -43,7 +43,7 @@ impl SyntheticData {
         self.ecef_from_local.transform_point(&pt_local)
     }
 
-    pub fn bbox(&self) -> Aabb<f64> {
+    pub fn bbox(&self) -> Aabb {
         let local_min = Point3::new(-self.half_width, -self.half_width, -self.half_height);
         let local_max = Point3::new(self.half_width, self.half_width, self.half_height);
         Aabb::new(local_min, local_max).transform(&self.ecef_from_local)

--- a/point_cloud_test/tests/main.rs
+++ b/point_cloud_test/tests/main.rs
@@ -104,7 +104,7 @@ where
 fn check_point_culling_equality<F, C>(gen_culling: F)
 where
     F: FnOnce(SyntheticData) -> C,
-    C: PointCulling<f64> + ConvexPolyhedron<f64>,
+    C: PointCulling + ConvexPolyhedron<f64>,
 {
     let args = Arguments::default();
     let data = SyntheticData::new(args.width, args.height, args.num_points, args.seed);

--- a/point_cloud_test/tests/main.rs
+++ b/point_cloud_test/tests/main.rs
@@ -104,7 +104,7 @@ where
 fn check_point_culling_equality<F, C>(gen_culling: F)
 where
     F: FnOnce(SyntheticData) -> C,
-    C: PointCulling + ConvexPolyhedron<f64>,
+    C: PointCulling + ConvexPolyhedron,
 {
     let args = Arguments::default();
     let data = SyntheticData::new(args.width, args.height, args.num_points, args.seed);

--- a/point_viewer_grpc/src/lib.rs
+++ b/point_viewer_grpc/src/lib.rs
@@ -51,7 +51,7 @@ impl GrpcOctreeDataProvider {
 
     pub fn get_points_in_box(
         &self,
-        bounding_box: &Aabb<f64>,
+        bounding_box: &Aabb,
         mut func: impl FnMut(&[Point]) -> bool,
     ) -> Result<()> {
         let mut req = proto::GetPointsInBoxRequest::new();

--- a/sdl_viewer/src/box_drawer.rs
+++ b/sdl_viewer/src/box_drawer.rs
@@ -164,7 +164,7 @@ impl BoxDrawer {
     // Then we use 'world_to_gl' to transform it into clip space.
     pub fn draw_outlines(
         &self,
-        cuboid: &Aabb<f64>,
+        cuboid: &Aabb,
         world_to_gl: &Matrix4<f64>,
         color: &color::Color<f32>,
     ) {

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -134,9 +134,7 @@ impl PointCloudRenderer {
         self.last_moving = time::Instant::now();
         self.needs_drawing = true;
         self.node_drawer.update_world_to_gl(world_to_gl);
-        self.get_visible_nodes_params_tx
-            .send(*world_to_gl)
-            .unwrap();
+        self.get_visible_nodes_params_tx.send(*world_to_gl).unwrap();
         self.last_moving = time::Instant::now();
         self.world_to_gl = *world_to_gl;
     }

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -135,7 +135,7 @@ impl PointCloudRenderer {
         self.needs_drawing = true;
         self.node_drawer.update_world_to_gl(world_to_gl);
         self.get_visible_nodes_params_tx
-            .send(world_to_gl.clone())
+            .send(*world_to_gl)
             .unwrap();
         self.last_moving = time::Instant::now();
         self.world_to_gl = *world_to_gl;

--- a/src/geometry/aabb.rs
+++ b/src/geometry/aabb.rs
@@ -4,7 +4,7 @@ use crate::math::base::PointCulling;
 use crate::math::sat::{ConvexPolyhedron, Intersector};
 use crate::proto;
 use arrayvec::ArrayVec;
-use nalgebra::{Isometry3, Point3, RealField, Vector3};
+use nalgebra::{Isometry3, Point3, Vector3};
 use serde::{Deserialize, Serialize};
 use std::iter::FromIterator;
 
@@ -94,7 +94,7 @@ impl From<&Aabb> for proto::AxisAlignedCuboid {
 
 impl PointCulling for Aabb {
     fn contains(&self, p: &Point3<f64>) -> bool {
-        self.contains(nalgebra::convert(p))
+        self.contains(p)
     }
 }
 

--- a/src/geometry/aabb.rs
+++ b/src/geometry/aabb.rs
@@ -101,7 +101,7 @@ impl PointCulling for Aabb {
 // This should be a tad more efficient than the generic ConvexPolyhedron
 // TODO(nnmm): Measure and remove if this does not represent a significant improvement
 impl<'a> HasAabbIntersector<'a> for Aabb {
-    type Intersector = CachedAxesIntersector<f64>;
+    type Intersector = CachedAxesIntersector;
     fn aabb_intersector(&'a self) -> Self::Intersector {
         CachedAxesIntersector {
             axes: vec![Vector3::x_axis(), Vector3::y_axis(), Vector3::z_axis()],
@@ -110,7 +110,7 @@ impl<'a> HasAabbIntersector<'a> for Aabb {
     }
 }
 
-impl ConvexPolyhedron<f64> for Aabb {
+impl ConvexPolyhedron for Aabb {
     fn compute_corners(&self) -> [Point3<f64>; 8] {
         [
             Point3::new(self.mins.x, self.mins.y, self.mins.z),
@@ -124,7 +124,7 @@ impl ConvexPolyhedron<f64> for Aabb {
         ]
     }
 
-    fn intersector(&self) -> Intersector<f64> {
+    fn intersector(&self) -> Intersector {
         let mut edges = ArrayVec::new();
         edges.push(Vector3::x_axis());
         edges.push(Vector3::y_axis());

--- a/src/geometry/aabb.rs
+++ b/src/geometry/aabb.rs
@@ -1,7 +1,7 @@
 //! Axis-aligned box and cube.
 
-use crate::math::base::{HasAabbIntersector, PointCulling};
-use crate::math::sat::{CachedAxesIntersector, ConvexPolyhedron, Intersector};
+use crate::math::base::PointCulling;
+use crate::math::sat::{ConvexPolyhedron, Intersector};
 use crate::proto;
 use arrayvec::ArrayVec;
 use nalgebra::{Isometry3, Point3, RealField, Vector3};
@@ -10,13 +10,13 @@ use std::iter::FromIterator;
 
 /// An axis-aligned bounding box.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-pub struct Aabb<S: RealField> {
-    mins: Point3<S>,
-    maxs: Point3<S>,
+pub struct Aabb {
+    mins: Point3<f64>,
+    maxs: Point3<f64>,
 }
 
-impl<S: RealField> Aabb<S> {
-    pub fn new(mins: Point3<S>, maxs: Point3<S>) -> Self {
+impl Aabb {
+    pub fn new(mins: Point3<f64>, maxs: Point3<f64>) -> Self {
         Aabb {
             mins: nalgebra::inf(&mins, &maxs),
             maxs: nalgebra::sup(&mins, &maxs),
@@ -30,32 +30,32 @@ impl<S: RealField> Aabb<S> {
         }
     }
 
-    pub fn min(&self) -> &Point3<S> {
+    pub fn min(&self) -> &Point3<f64> {
         &self.mins
     }
 
-    pub fn max(&self) -> &Point3<S> {
+    pub fn max(&self) -> &Point3<f64> {
         &self.maxs
     }
 
-    pub fn grow(&mut self, p: Point3<S>) {
+    pub fn grow(&mut self, p: Point3<f64>) {
         self.mins = nalgebra::inf(&self.mins, &p);
         self.maxs = nalgebra::sup(&self.maxs, &p);
     }
 
-    pub fn contains(&self, p: &Point3<S>) -> bool {
+    pub fn contains(&self, p: &Point3<f64>) -> bool {
         nalgebra::partial_le(&self.mins, p) && nalgebra::partial_lt(p, &self.maxs)
     }
 
-    pub fn center(&self) -> Point3<S> {
+    pub fn center(&self) -> Point3<f64> {
         nalgebra::center(&self.mins, &self.maxs)
     }
 
-    pub fn diag(&self) -> Vector3<S> {
+    pub fn diag(&self) -> Vector3<f64> {
         self.maxs - self.mins
     }
 
-    pub fn transform(&self, transform: &Isometry3<S>) -> Aabb<S> {
+    pub fn transform(&self, transform: &Isometry3<f64>) -> Aabb {
         let corners = self.compute_corners();
         let transformed_first = transform.transform_point(&corners[0]);
         let base = Self::new(transformed_first, transformed_first);
@@ -66,7 +66,7 @@ impl<S: RealField> Aabb<S> {
     }
 }
 
-impl From<&proto::AxisAlignedCuboid> for Aabb<f64> {
+impl From<&proto::AxisAlignedCuboid> for Aabb {
     fn from(aac: &proto::AxisAlignedCuboid) -> Self {
         let aac_min = aac.min.clone().unwrap_or_else(|| {
             let deprecated_min = aac.deprecated_min.clone().unwrap(); // Version 9
@@ -83,8 +83,8 @@ impl From<&proto::AxisAlignedCuboid> for Aabb<f64> {
     }
 }
 
-impl From<&Aabb<f64>> for proto::AxisAlignedCuboid {
-    fn from(bbox: &Aabb<f64>) -> Self {
+impl From<&Aabb> for proto::AxisAlignedCuboid {
+    fn from(bbox: &Aabb) -> Self {
         let mut aac = proto::AxisAlignedCuboid::new();
         aac.set_min(proto::Vector3d::from(bbox.min()));
         aac.set_max(proto::Vector3d::from(bbox.max()));
@@ -92,24 +92,24 @@ impl From<&Aabb<f64>> for proto::AxisAlignedCuboid {
     }
 }
 
-impl<S: RealField> PointCulling<S> for Aabb<S> {
-    fn contains(&self, p: &Point3<S>) -> bool {
-        self.contains(p)
+impl PointCulling for Aabb {
+    fn contains(&self, p: &Point3<f64>) -> bool {
+        self.contains(nalgebra::convert(p))
     }
 }
 
-impl<'a, S: RealField> HasAabbIntersector<'a, S> for Aabb<S> {
-    type Intersector = CachedAxesIntersector<S>;
-    fn aabb_intersector(&'a self) -> CachedAxesIntersector<S> {
-        CachedAxesIntersector {
-            axes: vec![Vector3::x_axis(), Vector3::y_axis(), Vector3::z_axis()],
-            corners: self.compute_corners(),
-        }
-    }
-}
+// impl<'a> HasAabbIntersector<'a> for Aabb {
+//     type Intersector = CachedAxesIntersector<f64>;
+//     fn aabb_intersector(&'a self) -> Self::Intersector {
+//         CachedAxesIntersector {
+//             axes: vec![Vector3::x_axis(), Vector3::y_axis(), Vector3::z_axis()],
+//             corners: self.compute_corners(),
+//         }
+//     }
+// }
 
-impl<S: RealField> ConvexPolyhedron<S> for Aabb<S> {
-    fn compute_corners(&self) -> [Point3<S>; 8] {
+impl ConvexPolyhedron<f64> for Aabb {
+    fn compute_corners(&self) -> [Point3<f64>; 8] {
         [
             Point3::new(self.mins.x, self.mins.y, self.mins.z),
             Point3::new(self.maxs.x, self.mins.y, self.mins.z),
@@ -122,7 +122,7 @@ impl<S: RealField> ConvexPolyhedron<S> for Aabb<S> {
         ]
     }
 
-    fn intersector(&self) -> Intersector<S> {
+    fn intersector(&self) -> Intersector<f64> {
         let mut edges = ArrayVec::new();
         edges.push(Vector3::x_axis());
         edges.push(Vector3::y_axis());
@@ -144,7 +144,7 @@ pub struct Cube {
 }
 
 impl Cube {
-    pub fn bounding(aabb: &Aabb<f64>) -> Self {
+    pub fn bounding(aabb: &Aabb) -> Self {
         let edge_length = (aabb.max().x - aabb.min().x)
             .max(aabb.max().y - aabb.min().y)
             .max(aabb.max().z - aabb.min().z);
@@ -154,7 +154,7 @@ impl Cube {
         }
     }
 
-    pub fn to_aabb(&self) -> Aabb<f64> {
+    pub fn to_aabb(&self) -> Aabb {
         Aabb::new(self.min(), self.max())
     }
 

--- a/src/geometry/aabb.rs
+++ b/src/geometry/aabb.rs
@@ -1,7 +1,7 @@
 //! Axis-aligned box and cube.
 
-use crate::math::base::PointCulling;
-use crate::math::sat::{ConvexPolyhedron, Intersector};
+use crate::math::base::{HasAabbIntersector, PointCulling};
+use crate::math::sat::{CachedAxesIntersector, ConvexPolyhedron, Intersector};
 use crate::proto;
 use arrayvec::ArrayVec;
 use nalgebra::{Isometry3, Point3, Vector3};
@@ -98,15 +98,17 @@ impl PointCulling for Aabb {
     }
 }
 
-// impl<'a> HasAabbIntersector<'a> for Aabb {
-//     type Intersector = CachedAxesIntersector<f64>;
-//     fn aabb_intersector(&'a self) -> Self::Intersector {
-//         CachedAxesIntersector {
-//             axes: vec![Vector3::x_axis(), Vector3::y_axis(), Vector3::z_axis()],
-//             corners: self.compute_corners(),
-//         }
-//     }
-// }
+// This should be a tad more efficient than the generic ConvexPolyhedron
+// TODO(nnmm): Measure and remove if this does not represent a significant improvement
+impl<'a> HasAabbIntersector<'a> for Aabb {
+    type Intersector = CachedAxesIntersector<f64>;
+    fn aabb_intersector(&'a self) -> Self::Intersector {
+        CachedAxesIntersector {
+            axes: vec![Vector3::x_axis(), Vector3::y_axis(), Vector3::z_axis()],
+            corners: self.compute_corners(),
+        }
+    }
+}
 
 impl ConvexPolyhedron<f64> for Aabb {
     fn compute_corners(&self) -> [Point3<f64>; 8] {

--- a/src/geometry/frustum.rs
+++ b/src/geometry/frustum.rs
@@ -1,14 +1,14 @@
 //! An asymmetric frustum with an arbitrary 3D pose.
 
-use crate::math::base::{HasAabbIntersector, PointCulling};
-use crate::math::sat::{CachedAxesIntersector, ConvexPolyhedron, Intersector};
+use crate::math::base::PointCulling;
+use crate::math::sat::{ConvexPolyhedron, Intersector};
 use arrayvec::ArrayVec;
 use nalgebra::{Isometry3, Matrix4, Perspective3, Point3, Unit, Vector3};
 use serde::{Deserialize, Serialize};
 
 /// A perspective projection matrix analogous to cgmath::Perspective.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Perspective{
+pub struct Perspective {
     matrix: Matrix4<f64>,
 }
 
@@ -117,15 +117,12 @@ impl Frustum {
     }
 }
 
-impl PointCulling<f64> for Frustum {
+impl PointCulling for Frustum {
     fn contains(&self, point: &Point3<f64>) -> bool {
         let p_clip = self.clip_from_query.transform_point(point);
-        p_clip.coords.min() > -1.0
-            && p_clip.coords.max() < 1.0
+        p_clip.coords.min() > -1.0 && p_clip.coords.max() < 1.0
     }
 }
-
-has_aabb_intersector_for_convex_polyhedron!(Frustum);
 
 impl ConvexPolyhedron<f64> for Frustum {
     #[rustfmt::skip]
@@ -179,9 +176,9 @@ mod tests {
     #[test]
     fn compare_perspective() {
         impl Perspective {
-            pub fn new_fov(aspect: S, fovy: S, near: S, far: S) -> Self {
+            pub fn new_fov(aspect: f64, fovy: f64, near: f64, far: f64) -> Self {
                 assert!(
-                    fovy > 0.0 && fovy < S::pi(),
+                    fovy > 0.0 && fovy < f64::PI,
                     "`fovy` must be a number between 0 and π, found: {:?}",
                     fovy
                 );
@@ -190,7 +187,7 @@ mod tests {
                     "`aspect` must be a positive number, found: {:?}",
                     aspect
                 );
-                let angle = fovy * nalgebra::convert(0.5);
+                let angle = fovy * 0.5;
                 let ymax = near * angle.tan();
                 let xmax = ymax * aspect;
 
@@ -198,8 +195,8 @@ mod tests {
             }
         }
 
-        let persp_a: Perspective<f64> = Perspective::new_fov(1.2, 0.66, 1.0, 100.0);
-        let persp_b: Perspective<f64> = nalgebra::Perspective3::new(1.2, 0.66, 1.0, 100.0).into();
+        let persp_a: Perspective = Perspective::new_fov(1.2, 0.66, 1.0, 100.0);
+        let persp_b: Perspective = nalgebra::Perspective3::new(1.2, 0.66, 1.0, 100.0).into();
         for (el_a, el_b) in persp_a.as_matrix().iter().zip(persp_b.as_matrix().iter()) {
             assert_eq!(el_a, el_b);
         }

--- a/src/geometry/frustum.rs
+++ b/src/geometry/frustum.rs
@@ -1,7 +1,7 @@
 //! An asymmetric frustum with an arbitrary 3D pose.
 
-use crate::math::base::PointCulling;
-use crate::math::sat::{ConvexPolyhedron, Intersector};
+use crate::math::base::{HasAabbIntersector, PointCulling};
+use crate::math::sat::{CachedAxesIntersector, ConvexPolyhedron, Intersector};
 use arrayvec::ArrayVec;
 use nalgebra::{Isometry3, Matrix4, Perspective3, Point3, Unit, Vector3};
 use serde::{Deserialize, Serialize};
@@ -165,6 +165,8 @@ impl ConvexPolyhedron<f64> for Frustum {
         }
     }
 }
+
+has_aabb_intersector_for_convex_polyhedron!(Frustum);
 
 #[cfg(test)]
 mod tests {

--- a/src/geometry/frustum.rs
+++ b/src/geometry/frustum.rs
@@ -178,7 +178,7 @@ mod tests {
         impl Perspective {
             pub fn new_fov(aspect: f64, fovy: f64, near: f64, far: f64) -> Self {
                 assert!(
-                    fovy > 0.0 && fovy < f64::PI,
+                    fovy > 0.0 && fovy < std::f64::consts::PI,
                     "`fovy` must be a number between 0 and π, found: {:?}",
                     fovy
                 );

--- a/src/geometry/frustum.rs
+++ b/src/geometry/frustum.rs
@@ -124,7 +124,7 @@ impl PointCulling for Frustum {
     }
 }
 
-impl ConvexPolyhedron<f64> for Frustum {
+impl ConvexPolyhedron for Frustum {
     #[rustfmt::skip]
     fn compute_corners(&self) -> [Point3<f64>; 8] {
         let corner_from = |x, y, z| self.query_from_clip.transform_point(&Point3::new(x, y, z));
@@ -140,7 +140,7 @@ impl ConvexPolyhedron<f64> for Frustum {
         ]
     }
 
-    fn intersector(&self) -> Intersector<f64> {
+    fn intersector(&self) -> Intersector {
         let corners = self.compute_corners();
 
         let mut edges: ArrayVec<[Unit<Vector3<f64>>; 12]> = ArrayVec::new();

--- a/src/geometry/obb.rs
+++ b/src/geometry/obb.rs
@@ -1,8 +1,8 @@
 //! A bounding box with an arbitrary 3D pose.
 
 use super::aabb::Aabb;
-use crate::math::sat::{CachedAxesIntersector, ConvexPolyhedron, Intersector};
-use crate::math::{HasAabbIntersector, PointCulling};
+use crate::math::sat::{ConvexPolyhedron, Intersector};
+use crate::math::PointCulling;
 use arrayvec::ArrayVec;
 use nalgebra::{Isometry3, Point3, Unit, UnitQuaternion, Vector3};
 use serde::{Deserialize, Serialize};
@@ -16,8 +16,8 @@ pub struct Obb {
     half_extent: Vector3<f64>,
 }
 
-impl From<&Aabb<f64>> for Obb {
-    fn from(aabb: &Aabb<f64>) -> Self {
+impl From<&Aabb> for Obb {
+    fn from(aabb: &Aabb) -> Self {
         Obb::new(
             Isometry3::from_parts(aabb.center().coords.into(), UnitQuaternion::identity()),
             aabb.diag() * 0.5,
@@ -25,8 +25,8 @@ impl From<&Aabb<f64>> for Obb {
     }
 }
 
-impl From<Aabb<f64>> for Obb {
-    fn from(aabb: Aabb<f64>) -> Self {
+impl From<Aabb> for Obb {
+    fn from(aabb: Aabb) -> Self {
         Self::from(&aabb)
     }
 }
@@ -78,9 +78,7 @@ impl ConvexPolyhedron<f64> for Obb {
     }
 }
 
-has_aabb_intersector_for_convex_polyhedron!(Obb);
-
-impl PointCulling<f64> for Obb {
+impl PointCulling for Obb {
     fn contains(&self, p: &Point3<f64>) -> bool {
         let p = self.obb_from_query * p;
         p.x.abs() <= self.half_extent.x

--- a/src/geometry/obb.rs
+++ b/src/geometry/obb.rs
@@ -1,8 +1,8 @@
 //! A bounding box with an arbitrary 3D pose.
 
 use super::aabb::Aabb;
-use crate::math::sat::{ConvexPolyhedron, Intersector};
-use crate::math::PointCulling;
+use crate::math::base::{HasAabbIntersector, PointCulling};
+use crate::math::sat::{CachedAxesIntersector, ConvexPolyhedron, Intersector};
 use arrayvec::ArrayVec;
 use nalgebra::{Isometry3, Point3, Unit, UnitQuaternion, Vector3};
 use serde::{Deserialize, Serialize};
@@ -77,6 +77,8 @@ impl ConvexPolyhedron<f64> for Obb {
         }
     }
 }
+
+has_aabb_intersector_for_convex_polyhedron!(Obb);
 
 impl PointCulling for Obb {
     fn contains(&self, p: &Point3<f64>) -> bool {

--- a/src/geometry/obb.rs
+++ b/src/geometry/obb.rs
@@ -45,7 +45,7 @@ impl Obb {
     }
 }
 
-impl ConvexPolyhedron<f64> for Obb {
+impl ConvexPolyhedron for Obb {
     fn compute_corners(&self) -> [Point3<f64>; 8] {
         let corner_from = |x, y, z| self.query_from_obb * Point3::new(x, y, z);
         [
@@ -64,7 +64,7 @@ impl ConvexPolyhedron<f64> for Obb {
         ]
     }
 
-    fn intersector(&self) -> Intersector<f64> {
+    fn intersector(&self) -> Intersector {
         let mut edges = ArrayVec::new();
         edges.push(Unit::new_normalize(self.query_from_obb * Vector3::x()));
         edges.push(Unit::new_normalize(self.query_from_obb * Vector3::y()));

--- a/src/geometry/s2_cell_union.rs
+++ b/src/geometry/s2_cell_union.rs
@@ -5,21 +5,14 @@ use crate::geometry::Aabb;
 use crate::math::base::{HasAabbIntersector, IntersectAabb, PointCulling};
 use crate::math::sat::ConvexPolyhedron;
 use crate::math::FromPoint3;
-use nalgebra::{Point3, RealField};
+use nalgebra::Point3;
 use s2::{cell::Cell, cellid::CellID, region::Region};
 
 /// Checks for an intersection between a list of cells and a polyhedron.
 ///
 /// This is done by checking whether any cell in the list intersects
 /// a covering of the polyhedron with S2 cells.
-pub fn cells_intersecting_polyhedron<S>(
-    cells: &[Cell],
-    polyhedron: &impl ConvexPolyhedron<S>,
-) -> bool
-where
-    S: RealField,
-    f64: From<S>,
-{
+pub fn cells_intersecting_polyhedron(cells: &[Cell], polyhedron: &impl ConvexPolyhedron) -> bool {
     let polyhedron_corner_cells = polyhedron
         .compute_corners()
         .iter()

--- a/src/geometry/s2_cell_union.rs
+++ b/src/geometry/s2_cell_union.rs
@@ -31,31 +31,19 @@ where
     cells.iter().any(|cell| rect.intersects_cell(cell))
 }
 
-impl<S> PointCulling<S> for CellUnion
-where
-    S: RealField,
-    f64: From<S>,
-{
-    fn contains(&self, p: &Point3<S>) -> bool {
+impl PointCulling for CellUnion {
+    fn contains(&self, p: &Point3<f64>) -> bool {
         self.contains_cellid(&CellID::from_point(p))
     }
 }
 
-impl<S> IntersectAabb<S> for Vec<Cell>
-where
-    f64: From<S>,
-    S: RealField,
-{
-    fn intersect_aabb(&self, aabb: &Aabb<S>) -> bool {
+impl IntersectAabb for Vec<Cell> {
+    fn intersect_aabb(&self, aabb: &Aabb) -> bool {
         cells_intersecting_polyhedron(self, aabb)
     }
 }
 
-impl<'a, S> HasAabbIntersector<'a, S> for CellUnion
-where
-    f64: From<S>,
-    S: RealField,
-{
+impl<'a> HasAabbIntersector<'a> for CellUnion {
     type Intersector = Vec<Cell>;
     fn aabb_intersector(&'a self) -> Self::Intersector {
         self.0.iter().map(Cell::from).collect()

--- a/src/geometry/web_mercator_rect.rs
+++ b/src/geometry/web_mercator_rect.rs
@@ -1,7 +1,7 @@
 //! A Web Mercator axis-aligned rectangle.
 
-use crate::math::base::PointCulling;
-use crate::math::sat::{ConvexPolyhedron, Intersector};
+use crate::math::base::{HasAabbIntersector, PointCulling};
+use crate::math::sat::{CachedAxesIntersector, ConvexPolyhedron, Intersector};
 use crate::math::web_mercator::WebMercatorCoord;
 use arrayvec::ArrayVec;
 use nalgebra::{Point3, Unit, Vector2};
@@ -111,6 +111,8 @@ impl ConvexPolyhedron<f64> for WebMercatorRect {
         }
     }
 }
+
+has_aabb_intersector_for_convex_polyhedron!(WebMercatorRect);
 
 impl PointCulling for WebMercatorRect {
     fn contains(&self, point: &Point3<f64>) -> bool {

--- a/src/geometry/web_mercator_rect.rs
+++ b/src/geometry/web_mercator_rect.rs
@@ -57,7 +57,7 @@ impl WebMercatorRect {
 /// to Web Mercator, fall into the given rectangle.
 /// Implemented by extruding the rectangle's four corners along their altitude
 /// axis up and down, which results in a convex polyhedron.
-impl ConvexPolyhedron<f64> for WebMercatorRect {
+impl ConvexPolyhedron for WebMercatorRect {
     fn compute_corners(&self) -> [Point3<f64>; 8] {
         let n_w = self.north_west.to_lat_lng();
         let s_e = self.south_east.to_lat_lng();
@@ -78,7 +78,7 @@ impl ConvexPolyhedron<f64> for WebMercatorRect {
         ]
     }
 
-    fn intersector(&self) -> Intersector<f64> {
+    fn intersector(&self) -> Intersector {
         let corners = self.compute_corners();
         let edges = ArrayVec::from([
             Unit::new_normalize(corners[1] - corners[0]), // N edge, down

--- a/src/geometry/web_mercator_rect.rs
+++ b/src/geometry/web_mercator_rect.rs
@@ -1,10 +1,10 @@
 //! A Web Mercator axis-aligned rectangle.
 
-use crate::math::base::{HasAabbIntersector, PointCulling};
-use crate::math::sat::{CachedAxesIntersector, ConvexPolyhedron, Intersector};
+use crate::math::base::PointCulling;
+use crate::math::sat::{ConvexPolyhedron, Intersector};
 use crate::math::web_mercator::WebMercatorCoord;
 use arrayvec::ArrayVec;
-use nalgebra::{Point3, RealField, Unit, Vector2};
+use nalgebra::{Point3, Unit, Vector2};
 use nav_types::{ECEF, WGS84};
 use serde::{Deserialize, Serialize};
 
@@ -112,15 +112,9 @@ impl ConvexPolyhedron<f64> for WebMercatorRect {
     }
 }
 
-has_aabb_intersector_for_convex_polyhedron!(WebMercatorRect);
-
-impl<S: RealField> PointCulling<S> for WebMercatorRect
-where
-    f64: From<S>,
-{
-    fn contains(&self, point: &Point3<S>) -> bool {
-        let ll: WGS84<f64> =
-            ECEF::new(f64::from(point.x), f64::from(point.y), f64::from(point.z)).into();
+impl PointCulling for WebMercatorRect {
+    fn contains(&self, point: &Point3<f64>) -> bool {
+        let ll: WGS84<f64> = ECEF::new(point.x, point.y, point.z).into();
         let wmc = WebMercatorCoord::from_lat_lng(&ll);
         nalgebra::partial_le(&self.north_west, &wmc) && nalgebra::partial_lt(&wmc, &self.south_east)
     }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, HashMap};
 pub enum PointLocation {
     AllPoints,
     Aabb(Aabb<f64>),
-    Frustum(Frustum<f64>),
+    Frustum(Frustum),
     Obb(Obb<f64>),
     S2Cells(CellUnion),
     WebMercatorRect(WebMercatorRect),

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeMap, HashMap};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PointLocation {
     AllPoints,
-    Aabb(Aabb<f64>),
+    Aabb(Aabb),
     Frustum(Frustum),
     Obb(Obb),
     S2Cells(CellUnion),
@@ -26,7 +26,7 @@ impl Default for PointLocation {
 }
 
 impl PointLocation {
-    pub fn get_point_culling(&self) -> Box<dyn PointCulling<f64>> {
+    pub fn get_point_culling(&self) -> Box<dyn PointCulling> {
         match &self {
             PointLocation::AllPoints => Box::new(AllPoints {}),
             PointLocation::Aabb(aabb) => Box::new(aabb.clone()),
@@ -73,7 +73,7 @@ pub struct PointQuery<'a> {
 
 /// Iterator over the points of a point cloud node within the specified PointCulling
 /// Essentially a specialized version of the Filter iterator adapter
-pub struct FilteredIterator<'a, Culling: PointCulling<f64>> {
+pub struct FilteredIterator<'a, Culling: PointCulling> {
     pub culling: Culling,
     pub filter_intervals: &'a HashMap<&'a str, ClosedInterval<f64>>,
     pub node_iterator: NodeIterator,
@@ -90,7 +90,7 @@ where
     }
 }
 
-impl<'a, Culling: PointCulling<f64>> Iterator for FilteredIterator<'a, Culling> {
+impl<'a, Culling: PointCulling> Iterator for FilteredIterator<'a, Culling> {
     type Item = PointsBatch;
 
     fn next(&mut self) -> Option<PointsBatch> {
@@ -177,7 +177,7 @@ pub trait PointCloud: Sync {
         node_id: Self::Id,
         batch_size: usize,
     ) -> Result<NodeIterator>;
-    fn bounding_box(&self) -> &Aabb<f64>;
+    fn bounding_box(&self) -> &Aabb;
 
     /// Return the points matching the query in the selected node.
     /// Why only a single node? Because the nodes are distributed to several `PointStream` instances
@@ -207,7 +207,7 @@ pub trait PointCloud: Sync {
 
 // TODO(nnmm): Instead of having this helper function, make stream_points_for_query_in_node
 // accept a T: PointCulling, so we can dispatch to this function directly
-fn stream<'a, T: PointCulling<f64> + Clone, F: FnMut(PointsBatch) -> Result<()>>(
+fn stream<'a, T: PointCulling + Clone, F: FnMut(PointsBatch) -> Result<()>>(
     intv: &'a HashMap<&'a str, ClosedInterval<f64>>,
     itr: NodeIterator,
     callback: F,

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -14,7 +14,7 @@ pub enum PointLocation {
     AllPoints,
     Aabb(Aabb<f64>),
     Frustum(Frustum),
-    Obb(Obb<f64>),
+    Obb(Obb),
     S2Cells(CellUnion),
     WebMercatorRect(WebMercatorRect),
 }

--- a/src/math/base.rs
+++ b/src/math/base.rs
@@ -1,19 +1,15 @@
 use crate::geometry::Aabb;
 use crate::math::sat::{CachedAxesIntersector, ConvexPolyhedron, Relation};
-use nalgebra::{Point3, RealField};
-use num_traits::Bounded;
+use nalgebra::Point3;
 
-pub trait PointCulling<S>
-where
-    S: RealField,
-{
-    fn contains(&self, point: &Point3<S>) -> bool;
+pub trait PointCulling {
+    fn contains(&self, point: &Point3<f64>) -> bool;
 }
 
 /// Something that can perform an intersection test with an AABB.
-pub trait IntersectAabb<S: RealField> {
+pub trait IntersectAabb {
     // TODO(nnmm): return Relation
-    fn intersect_aabb(&self, aabb: &Aabb<S>) -> bool;
+    fn intersect_aabb(&self, aabb: &Aabb) -> bool;
 }
 
 /// We use this trait to allow an indirection: The geometry itself does not need to be able to
@@ -22,37 +18,36 @@ pub trait IntersectAabb<S: RealField> {
 /// The trait has a lifetime to support the intersector borrowing from self, or being identical to
 /// &Self.
 ///
-/// Having `impl<'a, T: IntersectAabb<S>, S> HasAabbIntersector<'a, S> for T` and
-/// `impl<'a, S, T: ConvexPolyhedron<S>> HasAabbIntersector<'a, S> for T` would be nice, but results
+/// Having `impl<'a, T: IntersectAabb, S> HasAabbIntersector<'a, S> for T` and
+/// `impl<'a, S, T: ConvexPolyhedron> HasAabbIntersector<'a, S> for T` would be nice, but results
 /// in conflicts.
-pub trait HasAabbIntersector<'a, S: RealField> {
-    type Intersector: IntersectAabb<S> + 'a;
+pub trait HasAabbIntersector<'a> {
+    type Intersector: IntersectAabb + 'a;
     fn aabb_intersector(&'a self) -> Self::Intersector;
 }
 
-impl<S: RealField + Bounded> IntersectAabb<S> for CachedAxesIntersector<S> {
-    fn intersect_aabb(&self, aabb: &Aabb<S>) -> bool {
+impl IntersectAabb for CachedAxesIntersector<f64> {
+    fn intersect_aabb(&self, aabb: &Aabb) -> bool {
         self.intersect(&aabb.compute_corners()) != Relation::Out
     }
 }
 
-/// Use this macro as a crutch for the missing
-/// `impl<'a, S, T: ConvexPolyhedron<S>> HasAabbIntersector<'a, S> for T`.
-macro_rules! has_aabb_intersector_for_convex_polyhedron {
-    ($type:tt<$param:tt>) => {
-        impl<'a, S: RealField> HasAabbIntersector<'a, S> for $type<$param> {
-            type Intersector = CachedAxesIntersector<S>;
-            fn aabb_intersector(&'a self) -> Self::Intersector {
-                self.intersector().cache_separating_axes_for_aabb()
-            }
-        }
-    };
-    ($type:ty) => {
-        impl<'a> HasAabbIntersector<'a, f64> for $type {
-            type Intersector = CachedAxesIntersector<f64>;
-            fn aabb_intersector(&'a self) -> Self::Intersector {
-                self.intersector().cache_separating_axes_for_aabb()
-            }
-        }
-    };
+impl<'a, T: ConvexPolyhedron<f64>> HasAabbIntersector<'a> for T {
+    type Intersector = CachedAxesIntersector<f64>;
+    fn aabb_intersector(&'a self) -> Self::Intersector {
+        self.intersector().cache_separating_axes_for_aabb()
+    }
 }
+
+// /// Use this macro as a crutch for the missing
+// /// `impl<'a, S, T: ConvexPolyhedron> HasAabbIntersector<'a, S> for T`.
+// macro_rules! has_aabb_intersector_for_convex_polyhedron {
+//     ($type:ty) => {
+//         impl<'a> HasAabbIntersector<'a, f64> for $type {
+//             type Intersector = CachedAxesIntersector<f64>;
+//             fn aabb_intersector(&'a self) -> Self::Intersector {
+//                 self.intersector().cache_separating_axes_for_aabb()
+//             }
+//         }
+//     };
+// }

--- a/src/math/base.rs
+++ b/src/math/base.rs
@@ -26,7 +26,7 @@ pub trait HasAabbIntersector<'a> {
     fn aabb_intersector(&'a self) -> Self::Intersector;
 }
 
-impl IntersectAabb for CachedAxesIntersector<f64> {
+impl IntersectAabb for CachedAxesIntersector {
     fn intersect_aabb(&self, aabb: &Aabb) -> bool {
         self.intersect(&aabb.compute_corners()) != Relation::Out
     }
@@ -37,7 +37,7 @@ impl IntersectAabb for CachedAxesIntersector<f64> {
 macro_rules! has_aabb_intersector_for_convex_polyhedron {
     ($type:ty) => {
         impl<'a> HasAabbIntersector<'a> for $type {
-            type Intersector = CachedAxesIntersector<f64>;
+            type Intersector = CachedAxesIntersector;
             fn aabb_intersector(&'a self) -> Self::Intersector {
                 self.intersector().cache_separating_axes_for_aabb()
             }

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -140,13 +140,13 @@ impl<S: RealField> FromPoint3<S> for ECEF<S> {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct AllPoints {}
 
-impl<S: RealField> IntersectAabb<S> for AllPoints {
-    fn intersect_aabb(&self, _aabb: &Aabb<S>) -> bool {
+impl IntersectAabb for AllPoints {
+    fn intersect_aabb(&self, _aabb: &Aabb) -> bool {
         true
     }
 }
 
-impl<'a, S: RealField> HasAabbIntersector<'a, S> for AllPoints {
+impl<'a> HasAabbIntersector<'a> for AllPoints {
     type Intersector = Self;
 
     fn aabb_intersector(&'a self) -> Self::Intersector {
@@ -154,11 +154,8 @@ impl<'a, S: RealField> HasAabbIntersector<'a, S> for AllPoints {
     }
 }
 
-impl<S> PointCulling<S> for AllPoints
-where
-    S: RealField,
-{
-    fn contains(&self, _p: &Point3<S>) -> bool {
+impl PointCulling for AllPoints {
+    fn contains(&self, _p: &Point3<f64>) -> bool {
         true
     }
 }

--- a/src/math/sat.rs
+++ b/src/math/sat.rs
@@ -11,9 +11,9 @@
 //! use point_viewer::math::sat::ConvexPolyhedron;
 //! use point_viewer::geometry::{Aabb, Obb, Frustum};
 //! // Use your imagination here
-//! let many_obbs: Vec<Obb<f64>> = unimplemented!();
-//! let many_aabbs: Vec<Aabb<f64>> = unimplemented!();
-//! let frustum: Frustum<f64> = unimplemented!();
+//! let many_obbs: Vec<Obb> = unimplemented!();
+//! let many_aabbs: Vec<Aabb> = unimplemented!();
+//! let frustum: Frustum = unimplemented!();
 //! // For a generic intersection, you can reuse the intersector:
 //! let frustum_intersector = frustum.intersector();
 //! for obb in many_obbs {

--- a/src/octree/generation.rs
+++ b/src/octree/generation.rs
@@ -253,7 +253,7 @@ fn subsample_children_into(
 }
 
 /// Returns the bounding box containing all points
-fn find_bounding_box(filename: impl AsRef<Path>) -> Aabb<f64> {
+fn find_bounding_box(filename: impl AsRef<Path>) -> Aabb {
     let mut bounding_box = None;
     let stream = PlyIterator::from_file(filename, NUM_POINTS_PER_BATCH).unwrap();
     let mut progress_bar = create_progress_bar(stream.num_points(), "Determining bounding box");
@@ -289,7 +289,7 @@ pub fn build_octree_from_file(
 pub fn build_octree(
     output_directory: impl AsRef<Path>,
     resolution: f64,
-    bounding_box: Aabb<f64>,
+    bounding_box: Aabb,
     input: impl Iterator<Item = PointsBatch> + NumberOfPoints + Send,
     attributes: &[&str],
 ) {

--- a/src/octree/mod.rs
+++ b/src/octree/mod.rs
@@ -43,7 +43,7 @@ mod tests;
 #[derive(Clone, Debug)]
 pub struct OctreeMeta {
     pub resolution: f64,
-    pub bounding_box: Aabb<f64>,
+    pub bounding_box: Aabb,
     attribute_data_types: HashMap<String, AttributeDataType>,
 }
 
@@ -59,7 +59,7 @@ impl OctreeMeta {
     /// meta data structure, but not its serialized form. So the data structure
     /// is initialized with color and intensity hardcoded until attributes are
     /// in the meta proto.
-    pub fn new_with_standard_attributes(resolution: f64, bounding_box: Aabb<f64>) -> Self {
+    pub fn new_with_standard_attributes(resolution: f64, bounding_box: Aabb) -> Self {
         let attribute_data_types = vec![
             ("color".to_string(), AttributeDataType::U8Vec3),
             ("intensity".to_string(), AttributeDataType::F32),
@@ -309,7 +309,7 @@ impl Octree {
         })
     }
 
-    fn nodes_in_location_impl<'a, T: HasAabbIntersector<'a, f64>>(
+    fn nodes_in_location_impl<'a, T: HasAabbIntersector<'a>>(
         &self,
         location: &'a T,
     ) -> Vec<NodeId> {
@@ -355,7 +355,7 @@ impl PointCloud for Octree {
     }
 
     /// return the bounding box saved in meta
-    fn bounding_box(&self) -> &Aabb<f64> {
+    fn bounding_box(&self) -> &Aabb {
         &self.meta.bounding_box
     }
 }

--- a/src/read_write/s2.rs
+++ b/src/read_write/s2.rs
@@ -21,7 +21,7 @@ pub struct S2Splitter<W> {
     writers: LruCache<CellID, W>,
     already_opened_writers: HashSet<CellID>,
     cell_stats: FnvHashMap<CellID, S2CellMeta>,
-    bounding_box: Option<Aabb<f64>>,
+    bounding_box: Option<Aabb>,
     attributes_seen: BTreeMap<String, AttributeDataType>,
     encoding: Encoding,
     open_mode: OpenMode,

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -37,7 +37,7 @@ impl S2CellMeta {
 pub struct S2Meta {
     cells: FnvHashMap<CellID, S2CellMeta>,
     attribute_data_types: HashMap<String, AttributeDataType>,
-    bounding_box: Aabb<f64>,
+    bounding_box: Aabb,
 }
 
 impl PointCloudMeta for S2Meta {
@@ -50,7 +50,7 @@ impl S2Meta {
     pub fn new(
         cells: FnvHashMap<CellID, S2CellMeta>,
         attribute_data_types: HashMap<String, AttributeDataType>,
-        bounding_box: Aabb<f64>,
+        bounding_box: Aabb,
     ) -> Self {
         S2Meta {
             cells,
@@ -70,7 +70,7 @@ impl S2Meta {
         &self.cells
     }
 
-    pub fn bounding_box(&self) -> &Aabb<f64> {
+    pub fn bounding_box(&self) -> &Aabb {
         &self.bounding_box
     }
 
@@ -190,7 +190,7 @@ impl PointCloud for S2Cells {
         Ok(node_iterator)
     }
 
-    fn bounding_box(&self) -> &Aabb<f64> {
+    fn bounding_box(&self) -> &Aabb {
         &self.meta.bounding_box
     }
 }

--- a/src/s2_cells/mod.rs
+++ b/src/s2_cells/mod.rs
@@ -218,7 +218,7 @@ impl S2Cells {
     /// Returns all cells that intersect this convex polyhedron
     fn cells_in_convex_polyhedron<T>(&self, poly: &T) -> Vec<CellID>
     where
-        T: ConvexPolyhedron<f64>,
+        T: ConvexPolyhedron,
     {
         // We could choose either a covering rect or a covering cap as a convex hull
         let point_cells = poly

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -114,7 +114,7 @@ pub trait ColoringStrategy: Send {
     fn process_point_data(
         &mut self,
         points_batch: &PointsBatch,
-        bbox: &Aabb<f64>,
+        bbox: &Aabb,
         image_size: Vector2<u32>,
     ) {
         let mut discretized_locations = Vec::with_capacity(points_batch.position.len());
@@ -468,7 +468,7 @@ pub struct XrayParameters {
 }
 
 pub fn xray_from_points(
-    bbox: &Aabb<f64>,
+    bbox: &Aabb,
     image_size: Vector2<u32>,
     mut coloring_strategy: Box<dyn ColoringStrategy>,
     parameters: &XrayParameters,
@@ -519,7 +519,7 @@ pub fn xray_from_points(
 }
 
 pub fn find_quadtree_bounding_rect_and_levels(
-    bbox: &Aabb<f64>,
+    bbox: &Aabb,
     tile_size_px: u32,
     pixel_size_m: f64,
 ) -> (Rect, u8) {
@@ -554,9 +554,9 @@ pub fn get_nodes_at_level(root_node: &Node, level: u8) -> Vec<Node> {
 }
 
 pub fn get_bounding_box(
-    bounding_box: &Aabb<f64>,
+    bounding_box: &Aabb,
     query_from_global: &Option<Isometry3<f64>>,
-) -> Aabb<f64> {
+) -> Aabb {
     match query_from_global {
         Some(query_from_global) => bounding_box.transform(&query_from_global),
         None => bounding_box.clone(),
@@ -627,7 +627,7 @@ pub fn build_xray_quadtree(
 pub fn create_leaf_nodes(
     leaf_nodes: Vec<Node>,
     deepest_level: u8,
-    bounding_box: &Aabb<f64>,
+    bounding_box: &Aabb,
     coloring_strategy_kind: &ColoringStrategyKind,
     parameters: &XrayParameters,
 ) -> ImageResult<FnvHashSet<NodeId>> {

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -553,10 +553,7 @@ pub fn get_nodes_at_level(root_node: &Node, level: u8) -> Vec<Node> {
     nodes_at_level
 }
 
-pub fn get_bounding_box(
-    bounding_box: &Aabb,
-    query_from_global: &Option<Isometry3<f64>>,
-) -> Aabb {
+pub fn get_bounding_box(bounding_box: &Aabb, query_from_global: &Option<Isometry3<f64>>) -> Aabb {
     match query_from_global {
         Some(query_from_global) => bounding_box.transform(&query_from_global),
         None => bounding_box.clone(),


### PR DESCRIPTION
Why is this better?
* The generics buy the ability to instantiate code with f32 (f32 and f64 are the only float types in Rust). However, queries in global coordinates (anything in ECEF, Web Mercator tile, S2 cell) require f64 precision anyway.
* De facto everything is always f64 (see iterator.rs, including the query and point coordinate type), and changing it would require a bunch of refactoring anyway. This just makes it official :) 
* Code becomes nicer to read and maintain: Fewer trait bounds everywhere, no more `nalgebra::convert()` etc.
* More things can be constants instead of run-time values, like `std::f64::consts::PI` instead of `S::pi()`.
* Compile times should improve a bit.