### PR TITLE
Migrate from structopt to clap.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,10 +613,40 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/clap-rs/clap/?rev=5b9dbee5db540f44c336c2db54ece444624c30ef#5b9dbee5db540f44c336c2db54ece444624c30ef"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/clap-rs/clap/?rev=5b9dbee5db540f44c336c2db54ece444624c30ef#5b9dbee5db540f44c336c2db54ece444624c30ef"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -695,7 +725,7 @@ checksum = "1fc755679c12bda8e5523a71e4d654b6bf2e14bd838dfc48cde6559a05caf7d1"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.33.0",
  "criterion-plot",
  "csv",
  "itertools 0.8.2",
@@ -1867,6 +1897,7 @@ dependencies = [
  "actix",
  "actix-web",
  "byteorder",
+ "clap 3.0.0-beta.1",
  "crossbeam-utils",
  "failure",
  "json",
@@ -1874,7 +1905,6 @@ dependencies = [
  "point_viewer",
  "serde",
  "serde_derive",
- "structopt",
  "time 0.2.9",
 ]
 
@@ -1892,6 +1922,12 @@ checksum = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 dependencies = [
  "num-traits 0.2.11",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aad937e768e4bd31ddf5f56ce5d1fa7d2e18d84d2aae49d2c45c65aa1cadba0"
 
 [[package]]
 name = "parking_lot"
@@ -2071,13 +2107,13 @@ dependencies = [
 name = "point_cloud_client"
 version = "0.1.0"
 dependencies = [
+ "clap 3.0.0-beta.1",
  "fnv",
  "nalgebra",
  "num_cpus",
  "point_viewer",
  "point_viewer_grpc",
  "protobuf",
- "structopt",
 ]
 
 [[package]]
@@ -2106,6 +2142,7 @@ dependencies = [
  "approx 0.3.2",
  "arrayvec",
  "byteorder",
+ "clap 3.0.0-beta.1",
  "crossbeam",
  "error-chain",
  "fnv",
@@ -2127,7 +2164,6 @@ dependencies = [
  "s2",
  "serde",
  "serde_derive",
- "structopt",
  "tempdir",
 ]
 
@@ -2135,7 +2171,7 @@ dependencies = [
 name = "point_viewer_grpc"
 version = "0.1.0"
 dependencies = [
- "clap",
+ "clap 2.33.0",
  "crossbeam-channel",
  "ctrlc",
  "futures 0.1.29",
@@ -2756,7 +2792,7 @@ name = "sdl_viewer"
 version = "0.1.0"
 dependencies = [
  "byteorder",
- "clap",
+ "clap 2.33.0",
  "fnv",
  "gl_generator",
  "image",
@@ -2958,28 +2994,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "structopt"
-version = "0.3.12"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8faa2719539bbe9d77869bfb15d4ee769f99525e707931452c97b693b3f159d"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88b8e18c69496aad6f9ddf4630dd7d585bcaf765786cb415b9aec2fe5a0430"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -3049,6 +3067,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3579,7 +3606,7 @@ checksum = "9afd061c1c7c8ef0a3d337fbf76fc8c098bd0dfefd4adaafef25a559352f2031"
 name = "xray"
 version = "0.1.0"
 dependencies = [
- "clap",
+ "clap 3.0.0-beta.1",
  "crossbeam",
  "fnv",
  "globwalk",
@@ -3601,7 +3628,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "streaming-stats",
- "structopt",
  "texture-synthesis",
  "urlencoded",
  "xray_proto_rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ edition = "2018"
 alga = "0.9.2"
 arrayvec = "0.5.1"
 byteorder = "1.3.4"
+clap = { git = "https://github.com/clap-rs/clap/", rev = "5b9dbee5db540f44c336c2db54ece444624c30ef" }
 crossbeam = "0.7.3"
 error-chain = "0.12.2"
 fnv = "1.0.6"
@@ -45,7 +46,6 @@ rayon = "1.3.0"
 s2 = { version = "0.0.10", features = ["serde"] }
 serde = "1.0.104"
 serde_derive = "1.0.104"
-structopt = "0.3.11"
 rand = "0.7.3"
 
 [dependencies.point_viewer_proto_rust]

--- a/octree_web_viewer/Cargo.toml
+++ b/octree_web_viewer/Cargo.toml
@@ -27,13 +27,13 @@ edition = "2018"
 actix = "0.9.0"
 actix-web = "2.0.0"
 byteorder = "1.3.4"
+clap = { git = "https://github.com/clap-rs/clap/", rev = "5b9dbee5db540f44c336c2db54ece444624c30ef" }
 crossbeam-utils = "0.7.2"
 failure = "0.1.7"
 json = "0.12.1"
 nalgebra = "0.20.0"
 serde = "1.0.104"
 serde_derive = "1.0.104"
-structopt = "0.3.11"
 time = "0.2.7"
 
 [dependencies.point_viewer]

--- a/octree_web_viewer/src/bin/points_web_viewer.rs
+++ b/octree_web_viewer/src/bin/points_web_viewer.rs
@@ -12,28 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap::Clap;
 use octree_web_viewer::backend_error::PointsViewerError;
 use octree_web_viewer::state::AppState;
 use octree_web_viewer::utils::start_octree_server;
 use point_viewer::data_provider::DataProviderFactory;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use structopt::StructOpt;
 
 /// HTTP web viewer for 3d points stored in OnDiskOctrees
-#[derive(StructOpt, Debug)]
-#[structopt(name = "points_web_viewer", about = "Visualizing points")]
+#[derive(Clap, Debug)]
+#[clap(name = "points_web_viewer", about = "Visualizing points")]
 pub struct CommandLineArguments {
     /// The octree directory to serve, including a trailing slash.
-    #[structopt(name = "DIR", parse(from_os_str))]
+    #[clap(name = "DIR", parse(from_os_str))]
     octree_path: PathBuf,
     /// Port to listen on.
-    #[structopt(default_value = "5433")]
+    #[clap(default_value = "5433")]
     port: u16,
     /// IP string.
-    #[structopt(default_value = "127.0.0.1")]
+    #[clap(default_value = "127.0.0.1")]
     ip: String,
-    #[structopt(default_value = "100")]
+    #[clap(default_value = "100")]
     cache_items: usize,
 }
 
@@ -55,7 +55,7 @@ pub fn state_from(args: CommandLineArguments) -> Result<AppState, PointsViewerEr
 }
 
 fn main() {
-    let args = CommandLineArguments::from_args();
+    let args = CommandLineArguments::parse();
 
     let ip_port = format!("{}:{}", args.ip, args.port);
 

--- a/point_cloud_client/Cargo.toml
+++ b/point_cloud_client/Cargo.toml
@@ -14,10 +14,10 @@ name = "point_cloud_client_test"
 path = "src/bin/test.rs"
 
 [dependencies]
+clap = { git = "https://github.com/clap-rs/clap/", rev = "5b9dbee5db540f44c336c2db54ece444624c30ef" }
 fnv = "1.0.6"
 nalgebra = "0.20.0"
 num_cpus ="1.12.0"
 point_viewer = { path = ".." }
 point_viewer_grpc = { path = "../point_viewer_grpc" }
 protobuf = "2.10.2"
-structopt = "0.3.11"

--- a/point_cloud_client/src/bin/test.rs
+++ b/point_cloud_client/src/bin/test.rs
@@ -1,13 +1,13 @@
-// This removes clippy warnings regarding redundant StructOpt.
+// This removes clippy warnings regarding redundant Clap.
 #![allow(clippy::redundant_closure)]
 
+use clap::Clap;
 use nalgebra::Point3;
 use point_cloud_client::PointCloudClientBuilder;
 use point_viewer::errors::{ErrorKind, Result};
 use point_viewer::geometry::Aabb;
 use point_viewer::iterator::{PointLocation, PointQuery};
 use point_viewer::PointsBatch;
-use structopt::StructOpt;
 
 // size for batch
 const BATCH_SIZE: usize = 1_000_000;
@@ -24,15 +24,15 @@ fn point3f64_from_str(s: &str) -> std::result::Result<Point3<f64>, &'static str>
     Ok(Point3::new(coords[0], coords[1], coords[2]))
 }
 
-#[derive(StructOpt)]
-#[structopt(about = "Simple point_cloud_client test.")]
+#[derive(Clap)]
+#[clap(about = "Simple point_cloud_client test.")]
 struct CommandlineArguments {
     /// The locations containing the octree data.
-    #[structopt(parse(from_str), required = true)]
+    #[clap(parse(from_str), required = true)]
     locations: Vec<String>,
 
     /// The minimum value of the bounding box to be queried.
-    #[structopt(
+    #[clap(
         long,
         default_value = "-500.0 -500.0 -500.0",
         parse(try_from_str = point3f64_from_str)
@@ -40,7 +40,7 @@ struct CommandlineArguments {
     min: Point3<f64>,
 
     /// The maximum value of the bounding box to be queried.
-    #[structopt(
+    #[clap(
         long,
         default_value = "500.0 500.0 500.0",
         parse(try_from_str = point3f64_from_str)
@@ -48,20 +48,20 @@ struct CommandlineArguments {
     max: Point3<f64>,
 
     /// The maximum number of points to return.
-    #[structopt(long, default_value = "50000000")]
+    #[clap(long, default_value = "50000000")]
     num_points: usize,
 
     /// The maximum number of threads to be running.
-    #[structopt(long, default_value = "30")]
+    #[clap(long, default_value = "30")]
     num_threads: usize,
 
     /// The maximum number of points sent through batch.
-    #[structopt(long, default_value = "500000")]
+    #[clap(long, default_value = "500000")]
     batch_size: usize,
 }
 
 fn main() {
-    let args = CommandlineArguments::from_args();
+    let args = CommandlineArguments::parse();
     let num_points = args.num_points;
     let point_cloud_client = PointCloudClientBuilder::new(&args.locations)
         .num_threads(args.num_threads)

--- a/point_cloud_client/src/bin/test.rs
+++ b/point_cloud_client/src/bin/test.rs
@@ -1,6 +1,3 @@
-// This removes clippy warnings regarding redundant Clap.
-#![allow(clippy::redundant_closure)]
-
 use clap::Clap;
 use nalgebra::Point3;
 use point_cloud_client::PointCloudClientBuilder;

--- a/src/bin/build_octree.rs
+++ b/src/bin/build_octree.rs
@@ -12,34 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap::Clap;
 use point_viewer::octree::build_octree_from_file;
 use rayon::ThreadPoolBuilder;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "build_octree")]
+#[derive(Clap, Debug)]
+#[clap(name = "build_octree")]
 struct CommandlineArguments {
     /// PLY/PTS file to parse for the points.
-    #[structopt(parse(from_os_str))]
+    #[clap(parse(from_os_str))]
     input: PathBuf,
 
     /// Output directory to write the octree into.
-    #[structopt(long, parse(from_os_str))]
+    #[clap(long, parse(from_os_str))]
     output_directory: PathBuf,
 
     /// Minimal precision that this point cloud should have.
     /// This decides on the number of bits used to encode each node.
-    #[structopt(long, default_value = "0.001")]
+    #[clap(long, default_value = "0.001")]
     resolution: f64,
 
     /// The number of threads used to shard octree building. Set this as high as possible for SSDs.
-    #[structopt(long, default_value = "10")]
+    #[clap(long, default_value = "10")]
     num_threads: usize,
 }
 
 fn main() {
-    let args = CommandlineArguments::from_args();
+    let args = CommandlineArguments::parse();
     ThreadPoolBuilder::new()
         .num_threads(args.num_threads)
         .build_global()

--- a/src/bin/upgrade_octree.rs
+++ b/src/bin/upgrade_octree.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap::Clap;
 use point_viewer::data_provider::{DataProvider, OnDiskDataProvider};
 use point_viewer::octree::NodeId;
 use point_viewer::proto;
@@ -20,13 +21,12 @@ use protobuf::Message;
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "upgrade_octree")]
+#[derive(Clap, Debug)]
+#[clap(name = "upgrade_octree")]
 struct CommandlineArguments {
     /// Directory of octree to upgrade.
-    #[structopt(parse(from_os_str))]
+    #[clap(parse(from_os_str))]
     directory: PathBuf,
 }
 
@@ -81,7 +81,7 @@ fn upgrade_version12(directory: &Path, mut meta: proto::Meta) {
 }
 
 fn main() {
-    let args = CommandlineArguments::from_args();
+    let args = CommandlineArguments::parse();
     let data_provider = OnDiskDataProvider {
         directory: args.directory.clone(),
     };

--- a/src/math/sat.rs
+++ b/src/math/sat.rs
@@ -121,7 +121,7 @@ impl Intersector {
             let is_dupe = dedup_axes.iter().any(|ax2: &Unit<Vector3<f64>>| {
                 let d1 = (ax1.as_ref() - ax2.as_ref()).norm_squared();
                 let d2 = (ax1.as_ref() + ax2.as_ref()).norm_squared();
-                d1.min(d2) < f64::EPSILON
+                d1.min(d2) < std::f64::EPSILON
             });
             if !is_dupe {
                 dedup_axes.push(ax1);
@@ -194,8 +194,8 @@ where
 }
 
 fn project_on_axis(corners: &[Point3<f64>], sep_axis: Unit<Vector3<f64>>) -> (f64, f64) {
-    let mut min_proj = f64::MAX;
-    let mut max_proj = f64::MIN;
+    let mut min_proj = std::f64::MAX;
+    let mut max_proj = std::f64::MIN;
     for corner in corners {
         let corner_proj = corner.coords.dot(&sep_axis);
         min_proj = min_proj.min(corner_proj);

--- a/xray/Cargo.toml
+++ b/xray/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 edition = "2018"
 
 [dependencies]
-clap = "2.33.0"
+clap = { git = "https://github.com/clap-rs/clap/", rev = "5b9dbee5db540f44c336c2db54ece444624c30ef" }
 crossbeam = "0.7.3"
 fnv = "1.0.6"
 globwalk = "0.8.0"
@@ -28,7 +28,6 @@ router = "0.6.0"
 serde = "1.0.104"
 serde_json = "1.0.48"
 serde_derive = "1.0.104"
-structopt = "0.3.11"
 texture-synthesis = "0.8.0"
 urlencoded = "0.6.0"
 streaming-stats = "0.2.3"

--- a/xray/src/bin/build_xray_quadtree.rs
+++ b/xray/src/bin/build_xray_quadtree.rs
@@ -6,7 +6,7 @@ use xray::build_quadtree::{run, Extension};
 struct NullExtension;
 
 impl Extension for NullExtension {
-    fn pre_init<'a, 'b>(app: clap::App<'a, 'b>) -> clap::App<'a, 'b> {
+    fn pre_init(app: clap::App) -> clap::App {
         app
     }
     fn query_from_global(_: &clap::ArgMatches) -> Option<Isometry3<f64>> {

--- a/xray/src/bin/inpaint_xray_quadtree.rs
+++ b/xray/src/bin/inpaint_xray_quadtree.rs
@@ -1,10 +1,10 @@
+use clap::Clap;
 use fnv::FnvHashSet;
 use quadtree::{Direction, NodeId};
 use std::error::Error;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 use xray::{
     generation::{assign_background_color, create_non_leaf_nodes, TileBackgroundColorArgument},
     inpaint::perform_inpainting,
@@ -12,8 +12,8 @@ use xray::{
     Meta,
 };
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "inpaint_xray_quadtrees")]
+#[derive(Clap, Debug)]
+#[clap(name = "inpaint_xray_quadtrees")]
 /// Inpaint a (possibly partial) xray quadtree. We assume that the input
 /// quadtree was generated with transparent background color, so we can
 /// determine which pixels to actually fill.
@@ -21,20 +21,20 @@ struct CommandlineArguments {
     /// Directory with the (possibly partial) quadtree to be inpainted.
     /// Needs to include all leaf nodes of the neighboring quadtrees as well
     /// for smooth inpainting results.
-    #[structopt(parse(from_os_str))]
+    #[clap(parse(from_os_str))]
     input_directory: PathBuf,
     /// Directory where to write the inpainted quadtree. Does *not*
     /// have to be disjoint from input_directory.
-    #[structopt(parse(from_os_str), long)]
+    #[clap(parse(from_os_str), long)]
     output_directory: PathBuf,
     /// Tile background color.
-    #[structopt(default_value = "white", long)]
+    #[clap(arg_enum, default_value = "white", long)]
     tile_background_color: TileBackgroundColorArgument,
     /// The inpainting distance in pixels to fill holes (particularly useful for high resolutions)
-    #[structopt(long)]
+    #[clap(long)]
     inpaint_distance_px: u8,
     /// The root node id to start inpainting with.
-    #[structopt(default_value = "r", long)]
+    #[clap(default_value = "r", long)]
     root_node_id: NodeId,
 }
 
@@ -96,7 +96,7 @@ fn copy_meta_pb(
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let args = CommandlineArguments::from_args();
+    let args = CommandlineArguments::parse();
     let input_directory = args.input_directory.canonicalize()?;
     if !args.output_directory.exists() {
         fs::create_dir_all(&args.output_directory)?;

--- a/xray/src/bin/merge_xray_quadtrees.rs
+++ b/xray/src/bin/merge_xray_quadtrees.rs
@@ -1,27 +1,27 @@
+use clap::Clap;
 use fnv::FnvHashSet;
 use point_viewer::color::Color;
 use quadtree::{Node, NodeId};
 use std::fs::create_dir_all;
 use std::io;
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 use xray::{generation, Meta, META_EXTENSION, META_FILENAME, META_PREFIX};
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "merge_xray_quadtrees")]
+#[derive(Clap, Debug)]
+#[clap(name = "merge_xray_quadtrees")]
 /// Merge partial xray quadtrees. We assume that the root
 /// of each quadtree belongs to the same level of the final
 /// quadtree.
 struct CommandlineArguments {
     /// Directory where to write the merged quadtree. Does *not*
     /// have to be disjoint from input_directories.
-    #[structopt(parse(from_os_str), long)]
+    #[clap(parse(from_os_str), long)]
     output_directory: PathBuf,
     /// Tile background color.
-    #[structopt(default_value = "white", long)]
+    #[clap(arg_enum, default_value = "white", long)]
     tile_background_color: generation::TileBackgroundColorArgument,
     /// Directories with, possibly multiple, partial xray quadtrees.
-    #[structopt(parse(from_os_str))]
+    #[clap(parse(from_os_str))]
     input_directories: Vec<PathBuf>,
 }
 
@@ -205,7 +205,7 @@ fn merge(
 }
 
 fn main() -> io::Result<()> {
-    let args = CommandlineArguments::from_args();
+    let args = CommandlineArguments::parse();
     args.input_directories
         .iter()
         .try_for_each(|directory| validate_input_directory(&directory))?;

--- a/xray/src/bin/upgrade_xray_quadtree.rs
+++ b/xray/src/bin/upgrade_xray_quadtree.rs
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap::Clap;
 use protobuf::Message;
 use std::fs::File;
 use std::io::{BufWriter, Cursor};
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 use xray::META_FILENAME;
 use xray_proto_rust::proto;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "upgrade_xray_quadtree")]
+#[derive(Clap, Debug)]
+#[clap(name = "upgrade_xray_quadtree")]
 struct CommandlineArguments {
     /// Directory of xray quadtree to upgrade.
-    #[structopt(parse(from_os_str))]
+    #[clap(parse(from_os_str))]
     directory: PathBuf,
 }
 
@@ -45,7 +45,7 @@ fn upgrade_version2(filename: &Path, mut meta: proto::Meta) {
 }
 
 fn main() {
-    let args = CommandlineArguments::from_args();
+    let args = CommandlineArguments::parse();
     let filename = args.directory.join(META_FILENAME);
 
     loop {

--- a/xray/src/bin/web_viewer.rs
+++ b/xray/src/bin/web_viewer.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap::value_t;
 use iron::mime::Mime;
 use iron::prelude::*;
 use router::Router;
@@ -45,17 +44,17 @@ fn main() {
     let matches = clap::App::new("web_viewer")
         .args(&[
             clap::Arg::with_name("port")
-                .help("Port to listen on for connections.")
+                .about("Port to listen on for connections.")
                 .long("port")
                 .takes_value(true),
             clap::Arg::with_name("quadtree_directory")
-                .help("Input directory of the quadtree directory to serve.")
+                .about("Input directory of the quadtree directory to serve.")
                 .index(1)
                 .required(true),
         ])
         .get_matches();
 
-    let port = value_t!(matches, "port", u16).unwrap_or(5434);
+    let port = matches.value_of_t("port").unwrap_or(5434);
     let quadtree_directory = PathBuf::from(matches.value_of("quadtree_directory").unwrap());
 
     let mut router = Router::new();

--- a/xray/src/build_quadtree.rs
+++ b/xray/src/build_quadtree.rs
@@ -100,8 +100,8 @@ fn parse_arguments<T: Extension>() -> clap::ArgMatches {
                 .about(
                     "Binning size for one attribute, e.g. --binning timestamp=30000000000, \
                      which will be applied to 'colored' and 'colored_with_intensity' strategies. \
-                     Colors will be first averaged within the same bin and then averaged over all
-                     bins, so e.g. for timestamped bins temporally closer points will get less
+                     Colors will be first averaged within the same bin and then averaged over all \
+                     bins, so e.g. for timestamped bins temporally closer points will get less \
                      weight than points temporally further away.")
                 .long("binning")
                 .takes_value(true),

--- a/xray/src/build_quadtree.rs
+++ b/xray/src/build_quadtree.rs
@@ -2,7 +2,7 @@ use crate::generation::{
     build_xray_quadtree, ColoringStrategyArgument, ColoringStrategyKind, ColormapArgument,
     TileBackgroundColorArgument, XrayParameters,
 };
-use clap::derive::ArgEnum;
+use clap::{crate_authors, derive::ArgEnum};
 use nalgebra::Isometry3;
 use point_cloud_client::PointCloudClientBuilder;
 use point_viewer::data_provider::DataProviderFactory;
@@ -21,7 +21,7 @@ pub trait Extension {
 fn parse_arguments<T: Extension>() -> clap::ArgMatches {
     let mut app = clap::App::new("build_xray_quadtree")
         .version("1.0")
-        .author("Holger H. Rapp <hrapp@lyft.com>")
+        .author(crate_authors!())
         .args(&[
             clap::Arg::with_name("output_directory")
                 .about("Output directory to write the X-Ray quadtree into.")

--- a/xray/src/build_quadtree.rs
+++ b/xray/src/build_quadtree.rs
@@ -143,7 +143,7 @@ pub fn run<T: Extension>(data_provider_factory: DataProviderFactory) {
         let arg = ColoringStrategyArgument::from_str(
             args.value_of("coloring_strategy")
                 .expect("coloring_strategy is invalid"),
-            true,
+            false,
         )
         .expect("coloring_strategy couldn't be parsed");
         match arg {
@@ -164,7 +164,7 @@ pub fn run<T: Extension>(data_provider_factory: DataProviderFactory) {
                         .expect("max_stddev is invalid"),
                     ColormapArgument::from_str(
                         args.value_of("colormap").expect("colormap is invalid"),
-                        true,
+                        false,
                     )
                     .expect("colormap couldn't be parsed"),
                 )
@@ -175,7 +175,7 @@ pub fn run<T: Extension>(data_provider_factory: DataProviderFactory) {
     let tile_background_color = TileBackgroundColorArgument::from_str(
         args.value_of("tile_background_color")
             .expect("tile_background_color is invalid"),
-        true,
+        false,
     )
     .expect("tile_background_color couldn't be parsed")
     .to_color();

--- a/xray/src/build_quadtree.rs
+++ b/xray/src/build_quadtree.rs
@@ -140,6 +140,7 @@ pub fn run<T: Extension>(data_provider_factory: DataProviderFactory) {
 
     let binning = args.value_of("binning").map(|f| parse_key_val(f).unwrap());
     let coloring_strategy_kind = {
+        use ColoringStrategyArgument::*;
         let arg = ColoringStrategyArgument::from_str(
             args.value_of("coloring_strategy")
                 .expect("coloring_strategy is invalid"),
@@ -147,28 +148,24 @@ pub fn run<T: Extension>(data_provider_factory: DataProviderFactory) {
         )
         .expect("coloring_strategy couldn't be parsed");
         match arg {
-            ColoringStrategyArgument::Xray => ColoringStrategyKind::XRay,
-            ColoringStrategyArgument::Colored => ColoringStrategyKind::Colored(binning),
-            ColoringStrategyArgument::ColoredWithIntensity => {
-                ColoringStrategyKind::ColoredWithIntensity(
-                    args.value_of_t("min_intensity")
-                        .expect("min_intensity is invalid"),
-                    args.value_of_t("max_intensity")
-                        .expect("max_intensity is invalid"),
-                    binning,
+            Xray => ColoringStrategyKind::XRay,
+            Colored => ColoringStrategyKind::Colored(binning),
+            ColoredWithIntensity => ColoringStrategyKind::ColoredWithIntensity(
+                args.value_of_t("min_intensity")
+                    .expect("min_intensity is invalid"),
+                args.value_of_t("max_intensity")
+                    .expect("max_intensity is invalid"),
+                binning,
+            ),
+            ColoredWithHeightStddev => ColoringStrategyKind::ColoredWithHeightStddev(
+                args.value_of_t("max_stddev")
+                    .expect("max_stddev is invalid"),
+                ColormapArgument::from_str(
+                    args.value_of("colormap").expect("colormap is invalid"),
+                    false,
                 )
-            }
-            ColoringStrategyArgument::ColoredWithHeightStddev => {
-                ColoringStrategyKind::ColoredWithHeightStddev(
-                    args.value_of_t("max_stddev")
-                        .expect("max_stddev is invalid"),
-                    ColormapArgument::from_str(
-                        args.value_of("colormap").expect("colormap is invalid"),
-                        false,
-                    )
-                    .expect("colormap couldn't be parsed"),
-                )
-            }
+                .expect("colormap couldn't be parsed"),
+            ),
         }
     };
 

--- a/xray/src/build_quadtree.rs
+++ b/xray/src/build_quadtree.rs
@@ -2,7 +2,7 @@ use crate::generation::{
     build_xray_quadtree, ColoringStrategyArgument, ColoringStrategyKind, ColormapArgument,
     TileBackgroundColorArgument, XrayParameters,
 };
-use clap::value_t;
+use clap::derive::ArgEnum;
 use nalgebra::Isometry3;
 use point_cloud_client::PointCloudClientBuilder;
 use point_viewer::data_provider::DataProviderFactory;
@@ -14,40 +14,40 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 pub trait Extension {
-    fn pre_init<'a, 'b>(app: clap::App<'a, 'b>) -> clap::App<'a, 'b>;
+    fn pre_init(app: clap::App) -> clap::App;
     fn query_from_global(matches: &clap::ArgMatches) -> Option<Isometry3<f64>>;
 }
 
-fn parse_arguments<T: Extension>() -> clap::ArgMatches<'static> {
+fn parse_arguments<T: Extension>() -> clap::ArgMatches {
     let mut app = clap::App::new("build_xray_quadtree")
         .version("1.0")
         .author("Holger H. Rapp <hrapp@lyft.com>")
         .args(&[
             clap::Arg::with_name("output_directory")
-                .help("Output directory to write the X-Ray quadtree into.")
+                .about("Output directory to write the X-Ray quadtree into.")
                 .long("output-directory")
                 .required(true)
                 .takes_value(true),
             clap::Arg::with_name("resolution")
-                .help("Size of 1px in meters on the finest X-Ray level.")
+                .about("Size of 1px in meters on the finest X-Ray level.")
                 .long("resolution")
                 .default_value("0.01"),
             clap::Arg::with_name("num_threads")
-                .help("The number of threads used to shard X-Ray tile building.")
+                .about("The number of threads used to shard X-Ray tile building.")
                 .takes_value(true)
                 .long("num-threads")
                 .default_value("10"),
             clap::Arg::with_name("tile_size")
-                .help("Size of finest X-Ray level tile in pixels. Must be a power of two.")
+                .about("Size of finest X-Ray level tile in pixels. Must be a power of two.")
                 .long("tile-size")
                 .default_value("256"),
             clap::Arg::with_name("coloring_strategy")
                 .long("coloring-strategy")
                 .takes_value(true)
-                .possible_values(&ColoringStrategyArgument::variants())
+                .possible_values(&ColoringStrategyArgument::VARIANTS)
                 .default_value("xray"),
             clap::Arg::with_name("min_intensity")
-                .help(
+                .about(
                     "Minimum intensity of all points for color scaling. \
                      Only used for 'colored_with_intensity'.",
                 )
@@ -56,7 +56,7 @@ fn parse_arguments<T: Extension>() -> clap::ArgMatches<'static> {
                 .default_value("0")
                 .required_if("coloring_strategy", "colored_with_intensity"),
             clap::Arg::with_name("max_intensity")
-                .help(
+                .about(
                     "Maximum intensity of all points for color scaling. \
                      Only used for 'colored_with_intensity'.",
                 )
@@ -65,14 +65,14 @@ fn parse_arguments<T: Extension>() -> clap::ArgMatches<'static> {
                 .default_value("1")
                 .required_if("coloring_strategy", "colored_with_intensity"),
             clap::Arg::with_name("colormap")
-                .help("How values are mapped to colors")
+                .about("How values are mapped to colors")
                 .long("colormap")
                 .takes_value(true)
-                .possible_values(&ColormapArgument::variants())
+                .possible_values(&ColormapArgument::VARIANTS)
                 .default_value("jet")
                 .required_if("coloring_strategy", "colored_with_height_stddev"),
             clap::Arg::with_name("max_stddev")
-                .help(
+                .about(
                     "Maximum standard deviation for colored_with_height_stddev. Every stddev above this \
                      will be clamped to this value and appear saturated in the X-Rays. \
                      Only used for 'colored_with_height_stddev'.",
@@ -82,22 +82,22 @@ fn parse_arguments<T: Extension>() -> clap::ArgMatches<'static> {
                 .default_value("1")
                 .required_if("coloring_strategy", "colored_with_height_stddev"),
             clap::Arg::with_name("point_cloud_locations")
-                .help("Point cloud locations to turn into xrays.")
+                .about("Point cloud locations to turn into xrays.")
                 .index(1)
                 .multiple(true)
                 .required(true),
             clap::Arg::with_name("tile_background_color")
                 .long("tile-background-color")
                 .takes_value(true)
-                .possible_values(&TileBackgroundColorArgument::variants())
+                .possible_values(&TileBackgroundColorArgument::VARIANTS)
                 .default_value("white"),
             clap::Arg::with_name("filter_interval")
-                .help("Filter intervals for attributes, e.g. --filter-interval intensity=2.0,51.0")
+                .about("Filter intervals for attributes, e.g. --filter-interval intensity=2.0,51.0")
                 .long("filter-interval")
                 .takes_value(true)
                 .multiple(true),
             clap::Arg::with_name("binning")
-                .help(
+                .about(
                     "Binning size for one attribute, e.g. --binning timestamp=30000000000, \
                      which will be applied to 'colored' and 'colored_with_intensity' strategies. \
                      Colors will be first averaged within the same bin and then averaged over all
@@ -106,7 +106,7 @@ fn parse_arguments<T: Extension>() -> clap::ArgMatches<'static> {
                 .long("binning")
                 .takes_value(true),
             clap::Arg::with_name("root_node_id")
-                .help("The root node id to start building with.")
+                .about("The root node id to start building with.")
                 .long("root-node-id")
                 .takes_value(true)
                 .default_value("r"),
@@ -140,28 +140,45 @@ pub fn run<T: Extension>(data_provider_factory: DataProviderFactory) {
 
     let binning = args.value_of("binning").map(|f| parse_key_val(f).unwrap());
     let coloring_strategy_kind = {
-        use ColoringStrategyArgument::*;
-        let arg = value_t!(args, "coloring_strategy", ColoringStrategyArgument)
-            .expect("coloring_strategy is invalid");
+        let arg = ColoringStrategyArgument::from_str(
+            args.value_of("coloring_strategy")
+                .expect("coloring_strategy is invalid"),
+            true,
+        )
+        .expect("coloring_strategy couldn't be parsed");
         match arg {
-            xray => ColoringStrategyKind::XRay,
-            colored => ColoringStrategyKind::Colored(binning),
-            colored_with_intensity => ColoringStrategyKind::ColoredWithIntensity(
-                value_t!(args, "min_intensity", f32).expect("min_intensity is invalid"),
-                value_t!(args, "max_intensity", f32).expect("max_intensity is invalid"),
-                binning,
-            ),
-            colored_with_height_stddev => ColoringStrategyKind::ColoredWithHeightStddev(
-                value_t!(args, "max_stddev", f32).expect("max_stddev is invalid"),
-                value_t!(args, "colormap", ColormapArgument).expect("colormap is invalid"),
-            ),
+            ColoringStrategyArgument::Xray => ColoringStrategyKind::XRay,
+            ColoringStrategyArgument::Colored => ColoringStrategyKind::Colored(binning),
+            ColoringStrategyArgument::ColoredWithIntensity => {
+                ColoringStrategyKind::ColoredWithIntensity(
+                    args.value_of_t("min_intensity")
+                        .expect("min_intensity is invalid"),
+                    args.value_of_t("max_intensity")
+                        .expect("max_intensity is invalid"),
+                    binning,
+                )
+            }
+            ColoringStrategyArgument::ColoredWithHeightStddev => {
+                ColoringStrategyKind::ColoredWithHeightStddev(
+                    args.value_of_t("max_stddev")
+                        .expect("max_stddev is invalid"),
+                    ColormapArgument::from_str(
+                        args.value_of("colormap").expect("colormap is invalid"),
+                        true,
+                    )
+                    .expect("colormap couldn't be parsed"),
+                )
+            }
         }
     };
 
-    let tile_background_color =
-        value_t!(args, "tile_background_color", TileBackgroundColorArgument)
-            .expect("tile_background_color is invalid")
-            .to_color();
+    let tile_background_color = TileBackgroundColorArgument::from_str(
+        args.value_of("tile_background_color")
+            .expect("tile_background_color is invalid"),
+        true,
+    )
+    .expect("tile_background_color couldn't be parsed")
+    .to_color();
 
     let output_directory = PathBuf::from(args.value_of("output_directory").unwrap());
 

--- a/xray/src/generation.rs
+++ b/xray/src/generation.rs
@@ -3,7 +3,7 @@
 use crate::colormap::{Colormap, Jet, Monochrome, PURPLISH};
 use crate::utils::{get_image_path, get_meta_pb_path};
 use crate::Meta;
-use clap::arg_enum;
+use clap::Clap;
 use fnv::{FnvHashMap, FnvHashSet};
 use image::{self, GenericImage, ImageResult, Rgba, RgbaImage};
 use imageproc::map::map_colors;
@@ -30,42 +30,36 @@ use std::path::{Path, PathBuf};
 // becomes.
 const NUM_Z_BUCKETS: f64 = 1024.;
 
-arg_enum! {
-    #[derive(Debug)]
-    #[allow(non_camel_case_types)]
-    pub enum ColoringStrategyArgument {
-        xray,
-        colored,
-        colored_with_intensity,
-        colored_with_height_stddev,
-    }
+#[derive(Clap, Debug)]
+#[clap(rename_all = "snake_case")]
+pub enum ColoringStrategyArgument {
+    Xray,
+    Colored,
+    ColoredWithIntensity,
+    ColoredWithHeightStddev,
 }
 
-arg_enum! {
-    #[derive(Debug)]
-    #[allow(non_camel_case_types)]
-    pub enum TileBackgroundColorArgument {
-        white,
-        transparent,
-    }
+#[derive(Clap, Debug)]
+#[clap(rename_all = "snake_case")]
+pub enum TileBackgroundColorArgument {
+    White,
+    Transparent,
 }
 
 impl TileBackgroundColorArgument {
     pub fn to_color(&self) -> Color<u8> {
         match self {
-            TileBackgroundColorArgument::white => WHITE.to_u8(),
-            TileBackgroundColorArgument::transparent => TRANSPARENT.to_u8(),
+            TileBackgroundColorArgument::White => WHITE.to_u8(),
+            TileBackgroundColorArgument::Transparent => TRANSPARENT.to_u8(),
         }
     }
 }
 
-arg_enum! {
-    #[derive(Debug)]
-    #[allow(non_camel_case_types)]
-    pub enum ColormapArgument {
-        jet,
-        purplish,
-    }
+#[derive(Clap, Debug)]
+#[clap(rename_all = "snake_case")]
+pub enum ColormapArgument {
+    Jet,
+    Purplish,
 }
 
 // Maps from attribute name to the bin size
@@ -92,10 +86,10 @@ impl ColoringStrategyKind {
             ColoredWithIntensity(min_intensity, max_intensity, binning) => Box::new(
                 IntensityColoringStrategy::new(*min_intensity, *max_intensity, binning.clone()),
             ),
-            ColoredWithHeightStddev(max_stddev, ColormapArgument::jet) => {
+            ColoredWithHeightStddev(max_stddev, ColormapArgument::Jet) => {
                 Box::new(HeightStddevColoringStrategy::new(*max_stddev, Jet {}))
             }
-            ColoredWithHeightStddev(max_stddev, ColormapArgument::purplish) => Box::new(
+            ColoredWithHeightStddev(max_stddev, ColormapArgument::Purplish) => Box::new(
                 HeightStddevColoringStrategy::new(*max_stddev, Monochrome(PURPLISH)),
             ),
         }


### PR DESCRIPTION
This cleans up and beautifies most code. The binary most affected by this is
```
build_xray_quadtree --help
```
As can be seen in the output below, the changes (in particular for enums) don't affect the input arguments.
 
Output of this branch:
```
build_xray_quadtree 1.0
Holger Rapp <hrapp@lyft.com>:Marco Feuerstein <mfeuerstein@lyft.com>:Nikolai Morin <nmorin@lyft.com>:Caterina Vitadello
<cvitadello@lyft.com>:Kamil Popielarz <kpopielarz@lyft.com>

USAGE:
    build_xray_quadtree [OPTIONS] <point_cloud_locations>... --output-directory <output_directory>

ARGS:
    <point_cloud_locations>...    Point cloud locations to turn into xrays.

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --binning <binning>
            Binning size for one attribute, e.g. --binning timestamp=30000000000, which will be applied to 'colored' and
            'colored_with_intensity' strategies. Colors will be first averaged within the same bin and then averaged
            over all bins, so e.g. for timestamped bins temporally closer points will get less weight than points
            temporally further away.
        --coloring-strategy <coloring_strategy>
             [default: xray]  [possible values: xray, colored, colored_with_intensity, colored_with_height_stddev]

        --colormap <colormap>
            How values are mapped to colors [default: jet]  [possible values: jet, purplish]

        --filter-interval <filter_interval>...
            Filter intervals for attributes, e.g. --filter-interval intensity=2.0,51.0

        --max-intensity <max_intensity>
            Maximum intensity of all points for color scaling. Only used for 'colored_with_intensity'. [default: 1]

        --max-stddev <max_stddev>
            Maximum standard deviation for colored_with_height_stddev. Every stddev above this will be clamped to this
            value and appear saturated in the X-Rays. Only used for 'colored_with_height_stddev'. [default: 1]
        --min-intensity <min_intensity>
            Minimum intensity of all points for color scaling. Only used for 'colored_with_intensity'. [default: 0]

        --num-threads <num_threads>
            The number of threads used to shard X-Ray tile building. [default: 10]

        --output-directory <output_directory>              Output directory to write the X-Ray quadtree into.
        --resolution <resolution>
            Size of 1px in meters on the finest X-Ray level. [default: 0.01]

        --root-node-id <root_node_id>                      The root node id to start building with. [default: r]
        --tile-background-color <tile_background_color>     [default: white]  [possible values: white, transparent]
        --tile-size <tile_size>
            Size of finest X-Ray level tile in pixels. Must be a power of two. [default: 256]
```

Output of master:
```
build_xray_quadtree 1.0
Holger H. Rapp <hrapp@lyft.com>

USAGE:
    build_xray_quadtree [OPTIONS] <point_cloud_locations>... --output-directory <output_directory>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --binning <binning>
            Binning size for one attribute, e.g. --binning timestamp=30000000000, which will be applied to 'colored' and
            'colored_with_intensity' strategies. Colors will be first averaged within the same bin and then averaged
            over all
                                 bins, so e.g. for timestamped bins temporally closer points will get less
                                 weight than points temporally further away.
        --coloring-strategy <coloring_strategy>
             [default: xray]  [possible values: xray, colored, colored_with_intensity, colored_with_height_stddev]

        --colormap <colormap>
            How values are mapped to colors [default: jet]  [possible values: jet, purplish]

        --filter-interval <filter_interval>...
            Filter intervals for attributes, e.g. --filter-interval intensity=2.0,51.0

        --max-intensity <max_intensity>
            Maximum intensity of all points for color scaling. Only used for 'colored_with_intensity'. [default: 1]

        --max-stddev <max_stddev>
            Maximum standard deviation for colored_with_height_stddev. Every stddev above this will be clamped to this
            value and appear saturated in the X-Rays. Only used for 'colored_with_height_stddev'. [default: 1]
        --min-intensity <min_intensity>
            Minimum intensity of all points for color scaling. Only used for 'colored_with_intensity'. [default: 0]

        --num-threads <num_threads>
            The number of threads used to shard X-Ray tile building. [default: 10]

        --output-directory <output_directory>              Output directory to write the X-Ray quadtree into.
        --resolution <resolution>
            Size of 1px in meters on the finest X-Ray level. [default: 0.01]

        --root-node-id <root_node_id>                      The root node id to start building with. [default: r]
        --tile-background-color <tile_background_color>     [default: white]  [possible values: white, transparent]
        --tile-size <tile_size>
            Size of finest X-Ray level tile in pixels. Must be a power of two. [default: 256]


ARGS:
    <point_cloud_locations>...    Point cloud locations to turn into xrays.
```