### PR TITLE
Revert to stable gl_generator.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "time 0.2.16",
- "version_check 0.9.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,8 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "gl_generator"
-version = "0.14.1"
-source = "git+https://github.com/feuerste/gl-rs?branch=feuerste/non_exhaustive#6bb6afe7ebbc12e0429635defae512576ba67b63"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
 dependencies = [
  "khronos_api",
  "log 0.4.8",
@@ -1473,8 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "khronos_api"
-version = "3.2.0"
-source = "git+https://github.com/feuerste/gl-rs?branch=feuerste/non_exhaustive#6bb6afe7ebbc12e0429635defae512576ba67b63"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "language-tags"
@@ -2687,6 +2689,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2774,6 +2787,7 @@ dependencies = [
  "point_viewer",
  "point_viewer_grpc",
  "rand 0.7.3",
+ "rustversion",
  "sdl2",
  "serde",
  "serde_derive",

--- a/sdl_viewer/Cargo.toml
+++ b/sdl_viewer/Cargo.toml
@@ -25,7 +25,6 @@ edition = "2018"
 
 [build-dependencies]
 gl_generator = "0.14.0"
-version_check = "0.9.2"
 
 [dependencies]
 byteorder = "1.3.4"

--- a/sdl_viewer/Cargo.toml
+++ b/sdl_viewer/Cargo.toml
@@ -24,8 +24,7 @@ authors = [
 edition = "2018"
 
 [build-dependencies]
-# TODO(feuerste): Adjust once https://github.com/brendanzab/gl-rs/pull/521 is merged and a stable version is released.
-gl_generator = { git = "https://github.com/feuerste/gl-rs", branch = "feuerste/non_exhaustive" }
+gl_generator = "0.14.0"
 version_check = "0.9.2"
 
 [dependencies]
@@ -37,6 +36,7 @@ lru = "0.5.1"
 nalgebra = "0.21.0"
 num-integer = "0.1.42"
 rand = "0.7.3"
+rustversion = "1.0.2"
 sdl2 = "0.34.0"
 serde = "1.0.111"
 serde_derive = "1.0.111"

--- a/sdl_viewer/build.rs
+++ b/sdl_viewer/build.rs
@@ -10,9 +10,4 @@ fn main() {
     Registry::new(Api::Gl, (4, 1), Profile::Core, Fallbacks::All, [])
         .write_bindings(StructGenerator, &mut file)
         .unwrap();
-
-    // TODO(feuerste): Remove this, once 1.40 is stable.
-    if version_check::is_min_version("1.40").unwrap_or(false) {
-        println!("cargo:rustc-cfg=clippy_has_missing_safety_doc");
-    }
 }

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -30,6 +30,8 @@ mod camera;
     clippy::unreadable_literal,
     clippy::unused_unit
 )]
+// TODO(feuerste): Remove rustversion from Cargo.toml and move this up once it is in stable clippy, too.
+#[rustversion::attr(not(stable), allow(clippy::manual_non_exhaustive))]
 pub mod opengl {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }

--- a/sdl_viewer/src/lib.rs
+++ b/sdl_viewer/src/lib.rs
@@ -31,7 +31,7 @@ mod camera;
     clippy::unused_unit
 )]
 // TODO(feuerste): Remove rustversion from Cargo.toml and move this up once it is in stable clippy, too.
-#[rustversion::attr(not(stable), allow(clippy::manual_non_exhaustive))]
+#[rustversion::attr(since(1.45), allow(clippy::manual_non_exhaustive))]
 pub mod opengl {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }


### PR DESCRIPTION
#462 fixed clippy problems with the gl_generator by a temporary branch. However, since the branch is [not going to be merged into the gl repo](https://github.com/brendanzab/gl-rs/pull/521), we switch back to the original version and wrap it with `allow(clippy::manual_non_exhaustive)`.