### PR TITLE
Fix matrix initialization.

### DIFF
--- a/xray/src/lib.rs
+++ b/xray/src/lib.rs
@@ -174,10 +174,10 @@ impl Meta {
             let e = &matrix_entries;
             #[rustfmt::skip]
             let mat = Matrix4::new(
-                e[0],  e[1],  e[2],  e[3],
-                e[4],  e[5],  e[6],  e[7],
-                e[8],  e[9],  e[10], e[11],
-                e[12], e[13], e[14], e[15],
+                e[0], e[4],  e[8], e[12],
+                e[1], e[5],  e[9], e[13],
+                e[2], e[6], e[10], e[14],
+                e[3], e[7], e[11], e[15],
             );
             nalgebra::convert(mat)
         };


### PR DESCRIPTION
https://github.com/cartographer-project/point_cloud_viewer/pull/415/files#diff-fedc635549c49a1867cf6b18f648e6b8R158-R165 introduced a bug when initializing a matrix from all values. cgmath takes column major values, while nalgebra takes row major ones.